### PR TITLE
Bug fixing and extensions

### DIFF
--- a/locales/en.po
+++ b/locales/en.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: BridgeWx\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-21 14:32+0200\n"
-"PO-Revision-Date: 2024-10-21 14:34+0200\n"
+"POT-Creation-Date: 2024-10-24 16:18+0200\n"
+"PO-Revision-Date: 2024-10-24 16:20+0200\n"
 "Last-Translator: BusyHarry\n"
 "Language-Team: \n"
 "Language: en\n"
@@ -408,11 +408,11 @@ msgstr "Game %2u: "
 msgid " niet gespeeld"
 msgstr " not played"
 
-#: ..\src\calcScore.cpp:1228 ..\src\debug.cpp:1020 ..\src\debug.cpp:1854
+#: ..\src\calcScore.cpp:1228 ..\src\debug.cpp:1021 ..\src\debug.cpp:1855
 msgid "NZ"
 msgstr "NS"
 
-#: ..\src\calcScore.cpp:1228 ..\src\debug.cpp:1020 ..\src\debug.cpp:1854
+#: ..\src\calcScore.cpp:1228 ..\src\debug.cpp:1021 ..\src\debug.cpp:1855
 msgid "OW"
 msgstr "EW"
 
@@ -557,7 +557,7 @@ msgstr "score"
 msgid "bonus"
 msgstr "bonus"
 
-#: ..\src\correctionsEnd.cpp:39 ..\src\debug.cpp:2092 ..\src\debug.cpp:2224
+#: ..\src\correctionsEnd.cpp:39 ..\src\debug.cpp:2079 ..\src\debug.cpp:2211
 msgid "spellen"
 msgstr "games"
 
@@ -799,7 +799,7 @@ msgstr "Debug console"
 msgid "Aanmaak/printen van gidsbriefjes"
 msgstr "Creation/print of guides"
 
-#: ..\src\debug.cpp:424 ..\src\debug.cpp:2112
+#: ..\src\debug.cpp:424 ..\src\debug.cpp:2099
 msgid "Gidsbriefjes"
 msgstr "Guides"
 
@@ -807,11 +807,11 @@ msgstr "Guides"
 msgid "Aanmaak/printen van scoreslips"
 msgstr "Creation/print of scoreslips"
 
-#: ..\src\debug.cpp:437 ..\src\debug.cpp:1984 ..\src\debug.cpp:1991
+#: ..\src\debug.cpp:437 ..\src\debug.cpp:1870 ..\src\debug.cpp:1978
 msgid "Scoreslips"
 msgstr "Scoreslips"
 
-#: ..\src\debug.cpp:522 ..\src\debug.cpp:1214 ..\src\debug.cpp:1666
+#: ..\src\debug.cpp:522 ..\src\debug.cpp:1215 ..\src\debug.cpp:1667
 msgid "Geen schema voorhanden"
 msgstr "No schema available for these data"
 
@@ -819,31 +819,31 @@ msgstr "No schema available for these data"
 msgid "debug window van "
 msgstr "debug window of "
 
-#: ..\src\debug.cpp:866
+#: ..\src\debug.cpp:867
 msgid "     ----> ronde fout <---, default ronde 1\n"
 msgstr "     ----> round error <---, default round 1\n"
 
-#: ..\src\debug.cpp:879
+#: ..\src\debug.cpp:880
 msgid "     ----> paar fout <---, default paar 1\n"
 msgstr "     ----> pair error <---, default pair 1\n"
 
-#: ..\src\debug.cpp:890 ..\src\debug.cpp:1371
+#: ..\src\debug.cpp:891 ..\src\debug.cpp:1372
 msgid "     ----> groep fout <---, default groep 1\n"
 msgstr "     ----> group error <---, default group 1\n"
 
-#: ..\src\debug.cpp:901
+#: ..\src\debug.cpp:902
 msgid "     ----> tafel fout <---\n"
 msgstr "     ----> table error <---\n"
 
-#: ..\src\debug.cpp:912
+#: ..\src\debug.cpp:913
 msgid "     ----> spel fout <---, default spel 1\n"
 msgstr "     ----> game error <---, default game 1\n"
 
-#: ..\src\debug.cpp:921
+#: ..\src\debug.cpp:922
 msgid "groep "
 msgstr "group "
 
-#: ..\src\debug.cpp:932
+#: ..\src\debug.cpp:933
 #, c-format
 msgid ""
 "\n"
@@ -852,165 +852,165 @@ msgstr ""
 "\n"
 "test-mode, group %u (%u)\n"
 
-#: ..\src\debug.cpp:977
+#: ..\src\debug.cpp:978
 msgid "alle"
 msgstr "all"
 
 #. TRANSLATORS: L: table to Borrow games from (same games on different tables)
-#: ..\src\debug.cpp:1052
+#: ..\src\debug.cpp:1053
 #, c-format
 msgid "L%u"
 msgstr "B%u"
 
-#: ..\src\debug.cpp:1086
+#: ..\src\debug.cpp:1087
 msgid "eventuele tekst boven ieder schema:"
 msgstr "any text above each schema:"
 
-#: ..\src\debug.cpp:1225
+#: ..\src\debug.cpp:1226
 #, c-format
 msgid "paar %u, ronde %u, tafel %u, richting %s, spellen %s, tegenpaar %u\n"
 msgstr "pair %u, round %u, table %u, direction %s, games %s, opponent %u\n"
 
-#: ..\src\debug.cpp:1233
+#: ..\src\debug.cpp:1234
 #, c-format
 msgid "paar %u, spel %u:\n"
 msgstr "pair %u, game %u:\n"
 
-#: ..\src\debug.cpp:1239
+#: ..\src\debug.cpp:1240
 #, c-format
 msgid "paar %u, spellen %s, tafel %u, richting %s, ronde %u, tegenpaar %u\n"
 msgstr "pair %u, games %s, table %u, direction %s, round %u, opponent %u\n"
 
-#: ..\src\debug.cpp:1247
+#: ..\src\debug.cpp:1248
 #, c-format
 msgid "paar %u, tafel %u:\n"
 msgstr "pair %u, table %u:\n"
 
-#: ..\src\debug.cpp:1251
+#: ..\src\debug.cpp:1252
 #, c-format
 msgid "paar %u, tafel %u, ronde %u, richting %s, spellen %s, tegenpaar %u\n"
 msgstr "pair %u, table %u, round %u, direction %s, games %s, opponent %u\n"
 
-#: ..\src\debug.cpp:1259
+#: ..\src\debug.cpp:1260
 #, c-format
 msgid "Ronde %u:\n"
 msgstr "Round %u:\n"
 
-#: ..\src\debug.cpp:1263
+#: ..\src\debug.cpp:1264
 #, c-format
 msgid "paar %2u, richting %s, tafel %2u, spellen %s\n"
 msgstr "pair %2u, direction %s, table %2u, games %s\n"
 
-#: ..\src\debug.cpp:1270
+#: ..\src\debug.cpp:1271
 #, c-format
 msgid "Ronde %u, spel %u:\n"
 msgstr "Round %u, game %u:\n"
 
-#: ..\src\debug.cpp:1281
+#: ..\src\debug.cpp:1282
 #, c-format
 msgid "ronde %u, spellen %s, paar %2u, richting %s, tafel %u\n"
 msgstr "round %u, games %s, pair %2u, direction %s, table %u\n"
 
-#: ..\src\debug.cpp:1290
+#: ..\src\debug.cpp:1291
 #, c-format
 msgid "spellen %s worden in ronde %u niet gespeeld\n"
 msgstr "games %s are not played in round %u\n"
 
-#: ..\src\debug.cpp:1295
+#: ..\src\debug.cpp:1296
 #, c-format
 msgid "Ronde %u, tafel %u:\n"
 msgstr "Round %u, table %u:\n"
 
-#: ..\src\debug.cpp:1299
+#: ..\src\debug.cpp:1300
 #, c-format
 msgid "ronde %u, tafel %u, spellen %s, paren %u (NZ) + %u (OW)\n"
 msgstr "round %u, table %u, games %s, pairs %u (NS) + %u (EW)\n"
 
-#: ..\src\debug.cpp:1306
+#: ..\src\debug.cpp:1307
 #, c-format
 msgid "Spel %u:\n"
 msgstr "Game %u:\n"
 
-#: ..\src\debug.cpp:1315
+#: ..\src\debug.cpp:1316
 #, c-format
 msgid "ronde %u, tafel %u, paren %2u (NZ) + %2u (OW)\n"
 msgstr "round %u, table %u, pairs %2u (NS) + %2u (EW)\n"
 
-#: ..\src\debug.cpp:1323
+#: ..\src\debug.cpp:1324
 #, c-format
 msgid "Tafel %u:\n"
 msgstr "Table %u:\n"
 
-#: ..\src\debug.cpp:1329
+#: ..\src\debug.cpp:1330
 #, c-format
 msgid "ronde %u, spellen %s, paren %2u (NZ) + %2u (OW)  %s\n"
 msgstr "round %u, games %s, pairs %2u (NS) + %2u (EW)  %s\n"
 
-#: ..\src\debug.cpp:1383
+#: ..\src\debug.cpp:1384
 #, c-format
 msgid "Huidige groep zit in wedstrijd schema, neem groep > %u\n"
 msgstr "Current group is within match-schema, take group > %u\n"
 
-#: ..\src\debug.cpp:1391
+#: ..\src\debug.cpp:1392
 msgid " initgidsdata mislukt\n"
 msgstr " init of guidedata failed\n"
 
-#: ..\src\debug.cpp:1395
+#: ..\src\debug.cpp:1396
 msgid "kies een schema"
 msgstr "choose a schema"
 
-#: ..\src\debug.cpp:1419
+#: ..\src\debug.cpp:1420
 msgid "aan"
 msgstr "on"
 
-#: ..\src\debug.cpp:1419
+#: ..\src\debug.cpp:1420
 #, c-format
 msgid "testen staat nu %s voor TestRSP()\n"
 msgstr "testen is now %s for TestRSP()\n"
 
-#: ..\src\debug.cpp:1419
+#: ..\src\debug.cpp:1420
 msgid "uit"
 msgstr "off"
 
-#: ..\src\debug.cpp:1440
+#: ..\src\debug.cpp:1441
 msgid " gedubbeld"
 msgstr " doubled"
 
-#: ..\src\debug.cpp:1440
+#: ..\src\debug.cpp:1441
 msgid " geredubbeld"
 msgstr " re-doubled"
 
-#: ..\src\debug.cpp:1441
+#: ..\src\debug.cpp:1442
 msgid "harten/schoppen"
 msgstr "hearts/spades"
 
-#: ..\src\debug.cpp:1441
+#: ..\src\debug.cpp:1442
 msgid "klaveren/ruiten"
 msgstr "clubs/diamonts"
 
-#: ..\src\debug.cpp:1441
+#: ..\src\debug.cpp:1442
 msgid "sans atout"
 msgstr "no trump"
 
-#: ..\src\debug.cpp:1512
+#: ..\src\debug.cpp:1513
 msgid "meer down dan te behalen aantal slagen??\n"
 msgstr "more down then contract-tricks??\n"
 
-#: ..\src\debug.cpp:1516
+#: ..\src\debug.cpp:1517
 #, c-format
 msgid "%d down %s, "
 msgstr "%d down %s, "
 
-#: ..\src\debug.cpp:1542
+#: ..\src\debug.cpp:1543
 msgid "meer slagen dan er in een spel zijn??\n"
 msgstr "more tricks then possible in a game??\n"
 
-#: ..\src\debug.cpp:1610
+#: ..\src\debug.cpp:1611
 #, c-format
 msgid "score kwetsbaar: %d, niet kwetsbaar: %d\n"
 msgstr "score vulnerable: %d, not vulnerable: %d\n"
 
-#: ..\src\debug.cpp:1617
+#: ..\src\debug.cpp:1618
 msgid ""
 "^-- onbekend kommando\n"
 "   [l]Rx[@]PySzTq = list [Ronde x] [Paar y] [Spel z] [Tafel q]\n"
@@ -1033,156 +1033,156 @@ msgstr ""
 "               with 'y' up/down-tricks [[re]doubled]\n"
 "   o         = overview active schema\n"
 
-#: ..\src\debug.cpp:1643
+#: ..\src\debug.cpp:1644
 msgid "deze groep is (nog) niet geinitialiseerd, defaults:\n"
 msgstr "this group is not initialized (yet), defaults:\n"
 
-#: ..\src\debug.cpp:1652
+#: ..\src\debug.cpp:1653
 #, c-format
 msgid "rondes %u, paren %u, tafels %u (%s)\n"
 msgstr "rounds %u, pairs %u, tables %u (%s)\n"
 
-#: ..\src\debug.cpp:1797
+#: ..\src\debug.cpp:1798
 #, c-format
 msgid "schema voor %2u tafels, %2u rondes, %2u paren (%s)\n"
 msgstr "schema for %2u tables, %2u rounds, %2u pairs (%s)\n"
 
-#: ..\src\debug.cpp:1809
+#: ..\src\debug.cpp:1810
 #, c-format
 msgid "paar %u heeft geen tegenpaar in ronde %u\n"
 msgstr "pair %u has no opponent in round %u\n"
 
-#: ..\src\debug.cpp:1814
+#: ..\src\debug.cpp:1815
 #, c-format
 msgid "paar %u heeft te groot tegenpaar %u in ronde %u\n"
 msgstr "pair %u has too high opponent %u in round %u\n"
 
-#: ..\src\debug.cpp:1819
+#: ..\src\debug.cpp:1820
 #, c-format
 msgid "paar %u speelt %u keer tegen paar %u\n"
 msgstr "pair %u plays %u times against pair %u\n"
 
-#: ..\src\debug.cpp:1823
+#: ..\src\debug.cpp:1824
 #, c-format
 msgid "paar %u heeft te grote spelset %u in ronde %u\n"
 msgstr "pair %u has a too large gameset %u in round %u\n"
 
-#: ..\src\debug.cpp:1828
+#: ..\src\debug.cpp:1829
 #, c-format
 msgid "paar %u heeft onbekende spelset %u in ronde %u\n"
 msgstr "pair %u has unknown gameset %u in round %u\n"
 
-#: ..\src\debug.cpp:1833
+#: ..\src\debug.cpp:1834
 #, c-format
 msgid "paar %u speelt %u keer set %u\n"
 msgstr "pair %u playes %u times set %u\n"
 
-#: ..\src\debug.cpp:1836
+#: ..\src\debug.cpp:1837
 #, c-format
 msgid "paar %u speelt maar %u keer\n"
 msgstr "pair %u playes only %u times\n"
 
-#: ..\src\debug.cpp:1853
+#: ..\src\debug.cpp:1854
 #, c-format
 msgid "in ronde %u, tafel %u zitten paar %u en %u in dezelfde richting (%s)\n"
 msgstr ""
 "in round %u, table %u pair %u and %u are playing in the same direction (%s)\n"
 
-#: ..\src\debug.cpp:1948
-msgid "RONDE :"
-msgstr "ROUND :"
-
-#: ..\src\debug.cpp:1949
-msgid "TAFEL :"
-msgstr "TABLE :"
-
-#: ..\src\debug.cpp:1950
-msgid "   NZ :"
-msgstr "   NS :"
-
-#: ..\src\debug.cpp:1951
-msgid "   OW :"
-msgstr "   EW :"
-
-#: ..\src\debug.cpp:1952
-msgid "par.NZ"
-msgstr "ini.NS"
-
-#: ..\src\debug.cpp:1953
-msgid "par.OW"
-msgstr "ini.EW"
-
-#: ..\src\debug.cpp:1954
-msgid "Spel"
-msgstr "Game"
-
-#: ..\src\debug.cpp:1955
-msgid "Kontrakt"
-msgstr "Contract"
-
-#: ..\src\debug.cpp:1956
-msgid "NZ       OW"
-msgstr "NS       EW"
-
-#: ..\src\debug.cpp:1957
-msgid "Res."
-msgstr "Res."
-
-#: ..\src\debug.cpp:1958
-msgid "Score NZ + of -"
-msgstr "Score NS + or -"
-
-#: ..\src\debug.cpp:1983
+#: ..\src\debug.cpp:1869
 #, c-format
 msgid ""
 "Set-grootte(%u) is te hoog,\n"
-"maximum is 4"
+"maximum is 6"
 msgstr ""
 "Set-size(%u) too large,\n"
-"maximum is 4"
+"maximum is 6"
 
-#: ..\src\debug.cpp:2089
+#: ..\src\debug.cpp:1941
+msgid "RONDE :"
+msgstr "ROUND :"
+
+#: ..\src\debug.cpp:1942
+msgid "TAFEL :"
+msgstr "TABLE :"
+
+#: ..\src\debug.cpp:1943
+msgid "   NZ :"
+msgstr "   NS :"
+
+#: ..\src\debug.cpp:1944
+msgid "   OW :"
+msgstr "   EW :"
+
+#: ..\src\debug.cpp:1945
+msgid "par.NZ"
+msgstr "ini.NS"
+
+#: ..\src\debug.cpp:1946
+msgid "par.OW"
+msgstr "ini.EW"
+
+#: ..\src\debug.cpp:1947
+msgid "Spel"
+msgstr "Game"
+
+#: ..\src\debug.cpp:1948
+msgid "Kontrakt"
+msgstr "Contract"
+
+#: ..\src\debug.cpp:1949
+msgid "NZ       OW"
+msgstr "NS       EW"
+
+#: ..\src\debug.cpp:1950
+msgid "Resultaat"
+msgstr " Result"
+
+#: ..\src\debug.cpp:1951
+msgid "Score NZ + of -"
+msgstr "Score NS + or -"
+
+#: ..\src\debug.cpp:2076
 msgid "ronde"
 msgstr "round"
 
-#: ..\src\debug.cpp:2090
+#: ..\src\debug.cpp:2077
 msgid "tafel"
 msgstr "table"
 
 # no error
-#: ..\src\debug.cpp:2091
+#: ..\src\debug.cpp:2078
 msgid "tegen"
 msgstr "opp."
 
-#: ..\src\debug.cpp:2094
+#: ..\src\debug.cpp:2081
 #, c-format
 msgid "schema: %22s"
 msgstr "schema: %22s"
 
-#: ..\src\debug.cpp:2120
+#: ..\src\debug.cpp:2107
 #, c-format
 msgid "Paar %-2u               %2u paren"
 msgstr "Pair %-2u               %2u pairs"
 
-#: ..\src\debug.cpp:2223
+#: ..\src\debug.cpp:2210
 msgid "ronde ->"
 msgstr "round ->"
 
-#: ..\src\debug.cpp:2225
+#: ..\src\debug.cpp:2212
 msgid "tfl"
 msgstr "tbl"
 
-#: ..\src\debug.cpp:2226
+#: ..\src\debug.cpp:2213
 #, c-format
 msgid "%u paren, %u rondes, %u spellen"
 msgstr "%u pairs, %u rounds, %u games"
 
-#: ..\src\debug.cpp:2227
+#: ..\src\debug.cpp:2214
 #, c-format
 msgid "Schema: %s"
 msgstr "Schema: %s"
 
-#: ..\src\debug.cpp:2281
+#: ..\src\debug.cpp:2268
 msgid "Schemaoverzicht"
 msgstr "Schemaoverview"
 
@@ -1234,8 +1234,8 @@ msgstr "Search for languages, folder found: '%s'"
 
 #: ..\src\main.cpp:428
 #, c-format
-msgid "Systeemtaal: %d, %s"
-msgstr "Systemlanguage: %d, %s"
+msgid "Systeemtaal: id=%d, %s"
+msgstr "Systemlanguage: id=%d, %s"
 
 #: ..\src\main.cpp:430
 msgid "Systeemtaal: de default systeem taal"

--- a/locales/en.po
+++ b/locales/en.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: BridgeWx\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-04 15:11+0200\n"
-"PO-Revision-Date: 2024-10-04 15:51+0200\n"
+"POT-Creation-Date: 2024-10-21 14:32+0200\n"
+"PO-Revision-Date: 2024-10-21 14:34+0200\n"
 "Last-Translator: BusyHarry\n"
 "Language-Team: \n"
 "Language: en\n"
@@ -408,11 +408,11 @@ msgstr "Game %2u: "
 msgid " niet gespeeld"
 msgstr " not played"
 
-#: ..\src\calcScore.cpp:1228 ..\src\debug.cpp:1007 ..\src\debug.cpp:1841
+#: ..\src\calcScore.cpp:1228 ..\src\debug.cpp:1020 ..\src\debug.cpp:1854
 msgid "NZ"
 msgstr "NS"
 
-#: ..\src\calcScore.cpp:1228 ..\src\debug.cpp:1007 ..\src\debug.cpp:1841
+#: ..\src\calcScore.cpp:1228 ..\src\debug.cpp:1020 ..\src\debug.cpp:1854
 msgid "OW"
 msgstr "EW"
 
@@ -477,7 +477,7 @@ msgstr "Error in parameter: "
 msgid " van "
 msgstr " of "
 
-#: ..\src\cfg.cpp:872 ..\src\main.cpp:666
+#: ..\src\cfg.cpp:872 ..\src\main.cpp:663
 msgid ", versie "
 msgstr ", version "
 
@@ -517,7 +517,7 @@ msgstr ""
 "  qx: enlarge fontsize with x%\n"
 "  u : Unittest/Autotest"
 
-#: ..\src\choiceMC.cpp:155
+#: ..\src\choiceMC.cpp:156
 #, c-format
 msgid "ChoiceMC: item %i geactiveerd"
 msgstr "ChoiceMC: item %i activated"
@@ -530,22 +530,17 @@ msgstr "ChoiceMC->mouseclick(timer running)"
 msgid "ChoiceMC->mouseclick(show)"
 msgstr "ChoiceMC->mouseclick(show)"
 
-#: ..\src\choiceMC.cpp:207
+#: ..\src\choiceMC.cpp:209
 #, c-format
 msgid "ChoiceMC() comboMinSize=%i, charWidth=%i"
 msgstr "ChoiceMC() comboMinSize=%i, charWidth=%i"
 
-#: ..\src\choiceMC.cpp:239
-#, c-format
-msgid "ShowSizes(%i,%u): GetSize=%i, TxtCtlGetSize=%i, GetTextRect=%i"
-msgstr "ShowSizes(%i,%u): GetSize=%i, TxtCtlGetSize=%i, GetTextRect=%i"
-
-#: ..\src\choiceMC.cpp:259
+#: ..\src\choiceMC.cpp:248
 #, c-format
 msgid "CheckAutoSize(%i): SetMinSize: txt+offset=%i, minsize=%i"
 msgstr "CheckAutoSize(%i): SetMinSize: txt+offset=%i, minsize=%i"
 
-#: ..\src\choiceMC.cpp:381
+#: ..\src\choiceMC.cpp:384
 #, c-format
 msgid "ChoiceMC::SetPopupWidth() size=%i, cols=%u, breedte=%i"
 msgstr "ChoiceMC::SetPopupWidth() size=%i, cols=%u, breedte=%i"
@@ -562,7 +557,7 @@ msgstr "score"
 msgid "bonus"
 msgstr "bonus"
 
-#: ..\src\correctionsEnd.cpp:39 ..\src\debug.cpp:2079 ..\src\debug.cpp:2211
+#: ..\src\correctionsEnd.cpp:39 ..\src\debug.cpp:2092 ..\src\debug.cpp:2224
 msgid "spellen"
 msgstr "games"
 
@@ -804,7 +799,7 @@ msgstr "Debug console"
 msgid "Aanmaak/printen van gidsbriefjes"
 msgstr "Creation/print of guides"
 
-#: ..\src\debug.cpp:424 ..\src\debug.cpp:2099
+#: ..\src\debug.cpp:424 ..\src\debug.cpp:2112
 msgid "Gidsbriefjes"
 msgstr "Guides"
 
@@ -812,43 +807,43 @@ msgstr "Guides"
 msgid "Aanmaak/printen van scoreslips"
 msgstr "Creation/print of scoreslips"
 
-#: ..\src\debug.cpp:437 ..\src\debug.cpp:1971 ..\src\debug.cpp:1978
+#: ..\src\debug.cpp:437 ..\src\debug.cpp:1984 ..\src\debug.cpp:1991
 msgid "Scoreslips"
 msgstr "Scoreslips"
 
-#: ..\src\debug.cpp:518 ..\src\debug.cpp:1201 ..\src\debug.cpp:1653
+#: ..\src\debug.cpp:522 ..\src\debug.cpp:1214 ..\src\debug.cpp:1666
 msgid "Geen schema voorhanden"
 msgstr "No schema available for these data"
 
-#: ..\src\debug.cpp:574
+#: ..\src\debug.cpp:587
 msgid "debug window van "
 msgstr "debug window of "
 
-#: ..\src\debug.cpp:853
+#: ..\src\debug.cpp:866
 msgid "     ----> ronde fout <---, default ronde 1\n"
 msgstr "     ----> round error <---, default round 1\n"
 
-#: ..\src\debug.cpp:866
+#: ..\src\debug.cpp:879
 msgid "     ----> paar fout <---, default paar 1\n"
 msgstr "     ----> pair error <---, default pair 1\n"
 
-#: ..\src\debug.cpp:877 ..\src\debug.cpp:1358
+#: ..\src\debug.cpp:890 ..\src\debug.cpp:1371
 msgid "     ----> groep fout <---, default groep 1\n"
 msgstr "     ----> group error <---, default group 1\n"
 
-#: ..\src\debug.cpp:888
+#: ..\src\debug.cpp:901
 msgid "     ----> tafel fout <---\n"
 msgstr "     ----> table error <---\n"
 
-#: ..\src\debug.cpp:899
+#: ..\src\debug.cpp:912
 msgid "     ----> spel fout <---, default spel 1\n"
 msgstr "     ----> game error <---, default game 1\n"
 
-#: ..\src\debug.cpp:908
+#: ..\src\debug.cpp:921
 msgid "groep "
 msgstr "group "
 
-#: ..\src\debug.cpp:919
+#: ..\src\debug.cpp:932
 #, c-format
 msgid ""
 "\n"
@@ -857,165 +852,165 @@ msgstr ""
 "\n"
 "test-mode, group %u (%u)\n"
 
-#: ..\src\debug.cpp:964
+#: ..\src\debug.cpp:977
 msgid "alle"
 msgstr "all"
 
 #. TRANSLATORS: L: table to Borrow games from (same games on different tables)
-#: ..\src\debug.cpp:1039
+#: ..\src\debug.cpp:1052
 #, c-format
 msgid "L%u"
 msgstr "B%u"
 
-#: ..\src\debug.cpp:1073
+#: ..\src\debug.cpp:1086
 msgid "eventuele tekst boven ieder schema:"
 msgstr "any text above each schema:"
 
-#: ..\src\debug.cpp:1212
+#: ..\src\debug.cpp:1225
 #, c-format
 msgid "paar %u, ronde %u, tafel %u, richting %s, spellen %s, tegenpaar %u\n"
 msgstr "pair %u, round %u, table %u, direction %s, games %s, opponent %u\n"
 
-#: ..\src\debug.cpp:1220
+#: ..\src\debug.cpp:1233
 #, c-format
 msgid "paar %u, spel %u:\n"
 msgstr "pair %u, game %u:\n"
 
-#: ..\src\debug.cpp:1226
+#: ..\src\debug.cpp:1239
 #, c-format
 msgid "paar %u, spellen %s, tafel %u, richting %s, ronde %u, tegenpaar %u\n"
 msgstr "pair %u, games %s, table %u, direction %s, round %u, opponent %u\n"
 
-#: ..\src\debug.cpp:1234
+#: ..\src\debug.cpp:1247
 #, c-format
 msgid "paar %u, tafel %u:\n"
 msgstr "pair %u, table %u:\n"
 
-#: ..\src\debug.cpp:1238
+#: ..\src\debug.cpp:1251
 #, c-format
 msgid "paar %u, tafel %u, ronde %u, richting %s, spellen %s, tegenpaar %u\n"
 msgstr "pair %u, table %u, round %u, direction %s, games %s, opponent %u\n"
 
-#: ..\src\debug.cpp:1246
+#: ..\src\debug.cpp:1259
 #, c-format
 msgid "Ronde %u:\n"
 msgstr "Round %u:\n"
 
-#: ..\src\debug.cpp:1250
+#: ..\src\debug.cpp:1263
 #, c-format
 msgid "paar %2u, richting %s, tafel %2u, spellen %s\n"
 msgstr "pair %2u, direction %s, table %2u, games %s\n"
 
-#: ..\src\debug.cpp:1257
+#: ..\src\debug.cpp:1270
 #, c-format
 msgid "Ronde %u, spel %u:\n"
 msgstr "Round %u, game %u:\n"
 
-#: ..\src\debug.cpp:1268
+#: ..\src\debug.cpp:1281
 #, c-format
 msgid "ronde %u, spellen %s, paar %2u, richting %s, tafel %u\n"
 msgstr "round %u, games %s, pair %2u, direction %s, table %u\n"
 
-#: ..\src\debug.cpp:1277
+#: ..\src\debug.cpp:1290
 #, c-format
 msgid "spellen %s worden in ronde %u niet gespeeld\n"
 msgstr "games %s are not played in round %u\n"
 
-#: ..\src\debug.cpp:1282
+#: ..\src\debug.cpp:1295
 #, c-format
 msgid "Ronde %u, tafel %u:\n"
 msgstr "Round %u, table %u:\n"
 
-#: ..\src\debug.cpp:1286
+#: ..\src\debug.cpp:1299
 #, c-format
 msgid "ronde %u, tafel %u, spellen %s, paren %u (NZ) + %u (OW)\n"
 msgstr "round %u, table %u, games %s, pairs %u (NS) + %u (EW)\n"
 
-#: ..\src\debug.cpp:1293
+#: ..\src\debug.cpp:1306
 #, c-format
 msgid "Spel %u:\n"
 msgstr "Game %u:\n"
 
-#: ..\src\debug.cpp:1302
+#: ..\src\debug.cpp:1315
 #, c-format
 msgid "ronde %u, tafel %u, paren %2u (NZ) + %2u (OW)\n"
 msgstr "round %u, table %u, pairs %2u (NS) + %2u (EW)\n"
 
-#: ..\src\debug.cpp:1310
+#: ..\src\debug.cpp:1323
 #, c-format
 msgid "Tafel %u:\n"
 msgstr "Table %u:\n"
 
-#: ..\src\debug.cpp:1316
+#: ..\src\debug.cpp:1329
 #, c-format
 msgid "ronde %u, spellen %s, paren %2u (NZ) + %2u (OW)  %s\n"
 msgstr "round %u, games %s, pairs %2u (NS) + %2u (EW)  %s\n"
 
-#: ..\src\debug.cpp:1370
+#: ..\src\debug.cpp:1383
 #, c-format
 msgid "Huidige groep zit in wedstrijd schema, neem groep > %u\n"
 msgstr "Current group is within match-schema, take group > %u\n"
 
-#: ..\src\debug.cpp:1378
+#: ..\src\debug.cpp:1391
 msgid " initgidsdata mislukt\n"
 msgstr " init of guidedata failed\n"
 
-#: ..\src\debug.cpp:1382
+#: ..\src\debug.cpp:1395
 msgid "kies een schema"
 msgstr "choose a schema"
 
-#: ..\src\debug.cpp:1406
+#: ..\src\debug.cpp:1419
 msgid "aan"
 msgstr "on"
 
-#: ..\src\debug.cpp:1406
+#: ..\src\debug.cpp:1419
 #, c-format
 msgid "testen staat nu %s voor TestRSP()\n"
 msgstr "testen is now %s for TestRSP()\n"
 
-#: ..\src\debug.cpp:1406
+#: ..\src\debug.cpp:1419
 msgid "uit"
 msgstr "off"
 
-#: ..\src\debug.cpp:1427
+#: ..\src\debug.cpp:1440
 msgid " gedubbeld"
 msgstr " doubled"
 
-#: ..\src\debug.cpp:1427
+#: ..\src\debug.cpp:1440
 msgid " geredubbeld"
 msgstr " re-doubled"
 
-#: ..\src\debug.cpp:1428
+#: ..\src\debug.cpp:1441
 msgid "harten/schoppen"
 msgstr "hearts/spades"
 
-#: ..\src\debug.cpp:1428
+#: ..\src\debug.cpp:1441
 msgid "klaveren/ruiten"
 msgstr "clubs/diamonts"
 
-#: ..\src\debug.cpp:1428
+#: ..\src\debug.cpp:1441
 msgid "sans atout"
 msgstr "no trump"
 
-#: ..\src\debug.cpp:1499
+#: ..\src\debug.cpp:1512
 msgid "meer down dan te behalen aantal slagen??\n"
 msgstr "more down then contract-tricks??\n"
 
-#: ..\src\debug.cpp:1503
+#: ..\src\debug.cpp:1516
 #, c-format
 msgid "%d down %s, "
 msgstr "%d down %s, "
 
-#: ..\src\debug.cpp:1529
+#: ..\src\debug.cpp:1542
 msgid "meer slagen dan er in een spel zijn??\n"
 msgstr "more tricks then possible in a game??\n"
 
-#: ..\src\debug.cpp:1597
+#: ..\src\debug.cpp:1610
 #, c-format
 msgid "score kwetsbaar: %d, niet kwetsbaar: %d\n"
 msgstr "score vulnerable: %d, not vulnerable: %d\n"
 
-#: ..\src\debug.cpp:1604
+#: ..\src\debug.cpp:1617
 msgid ""
 "^-- onbekend kommando\n"
 "   [l]Rx[@]PySzTq = list [Ronde x] [Paar y] [Spel z] [Tafel q]\n"
@@ -1038,106 +1033,106 @@ msgstr ""
 "               with 'y' up/down-tricks [[re]doubled]\n"
 "   o         = overview active schema\n"
 
-#: ..\src\debug.cpp:1630
+#: ..\src\debug.cpp:1643
 msgid "deze groep is (nog) niet geinitialiseerd, defaults:\n"
 msgstr "this group is not initialized (yet), defaults:\n"
 
-#: ..\src\debug.cpp:1639
+#: ..\src\debug.cpp:1652
 #, c-format
 msgid "rondes %u, paren %u, tafels %u (%s)\n"
 msgstr "rounds %u, pairs %u, tables %u (%s)\n"
 
-#: ..\src\debug.cpp:1784
+#: ..\src\debug.cpp:1797
 #, c-format
 msgid "schema voor %2u tafels, %2u rondes, %2u paren (%s)\n"
 msgstr "schema for %2u tables, %2u rounds, %2u pairs (%s)\n"
 
-#: ..\src\debug.cpp:1796
+#: ..\src\debug.cpp:1809
 #, c-format
 msgid "paar %u heeft geen tegenpaar in ronde %u\n"
 msgstr "pair %u has no opponent in round %u\n"
 
-#: ..\src\debug.cpp:1801
+#: ..\src\debug.cpp:1814
 #, c-format
 msgid "paar %u heeft te groot tegenpaar %u in ronde %u\n"
 msgstr "pair %u has too high opponent %u in round %u\n"
 
-#: ..\src\debug.cpp:1806
+#: ..\src\debug.cpp:1819
 #, c-format
 msgid "paar %u speelt %u keer tegen paar %u\n"
 msgstr "pair %u plays %u times against pair %u\n"
 
-#: ..\src\debug.cpp:1810
+#: ..\src\debug.cpp:1823
 #, c-format
 msgid "paar %u heeft te grote spelset %u in ronde %u\n"
 msgstr "pair %u has a too large gameset %u in round %u\n"
 
-#: ..\src\debug.cpp:1815
+#: ..\src\debug.cpp:1828
 #, c-format
 msgid "paar %u heeft onbekende spelset %u in ronde %u\n"
 msgstr "pair %u has unknown gameset %u in round %u\n"
 
-#: ..\src\debug.cpp:1820
+#: ..\src\debug.cpp:1833
 #, c-format
 msgid "paar %u speelt %u keer set %u\n"
 msgstr "pair %u playes %u times set %u\n"
 
-#: ..\src\debug.cpp:1823
+#: ..\src\debug.cpp:1836
 #, c-format
 msgid "paar %u speelt maar %u keer\n"
 msgstr "pair %u playes only %u times\n"
 
-#: ..\src\debug.cpp:1840
+#: ..\src\debug.cpp:1853
 #, c-format
 msgid "in ronde %u, tafel %u zitten paar %u en %u in dezelfde richting (%s)\n"
 msgstr ""
 "in round %u, table %u pair %u and %u are playing in the same direction (%s)\n"
 
-#: ..\src\debug.cpp:1935
+#: ..\src\debug.cpp:1948
 msgid "RONDE :"
 msgstr "ROUND :"
 
-#: ..\src\debug.cpp:1936
+#: ..\src\debug.cpp:1949
 msgid "TAFEL :"
 msgstr "TABLE :"
 
-#: ..\src\debug.cpp:1937
+#: ..\src\debug.cpp:1950
 msgid "   NZ :"
 msgstr "   NS :"
 
-#: ..\src\debug.cpp:1938
+#: ..\src\debug.cpp:1951
 msgid "   OW :"
 msgstr "   EW :"
 
-#: ..\src\debug.cpp:1939
+#: ..\src\debug.cpp:1952
 msgid "par.NZ"
 msgstr "ini.NS"
 
-#: ..\src\debug.cpp:1940
+#: ..\src\debug.cpp:1953
 msgid "par.OW"
 msgstr "ini.EW"
 
-#: ..\src\debug.cpp:1941
+#: ..\src\debug.cpp:1954
 msgid "Spel"
 msgstr "Game"
 
-#: ..\src\debug.cpp:1942
+#: ..\src\debug.cpp:1955
 msgid "Kontrakt"
 msgstr "Contract"
 
-#: ..\src\debug.cpp:1943
+#: ..\src\debug.cpp:1956
 msgid "NZ       OW"
 msgstr "NS       EW"
 
-#: ..\src\debug.cpp:1944
+#: ..\src\debug.cpp:1957
 msgid "Res."
 msgstr "Res."
 
-#: ..\src\debug.cpp:1945
+#: ..\src\debug.cpp:1958
 msgid "Score NZ + of -"
 msgstr "Score NS + or -"
 
-#: ..\src\debug.cpp:1970
+#: ..\src\debug.cpp:1983
 #, c-format
 msgid ""
 "Set-grootte(%u) is te hoog,\n"
@@ -1146,48 +1141,48 @@ msgstr ""
 "Set-size(%u) too large,\n"
 "maximum is 4"
 
-#: ..\src\debug.cpp:2076
+#: ..\src\debug.cpp:2089
 msgid "ronde"
 msgstr "round"
 
-#: ..\src\debug.cpp:2077
+#: ..\src\debug.cpp:2090
 msgid "tafel"
 msgstr "table"
 
 # no error
-#: ..\src\debug.cpp:2078
+#: ..\src\debug.cpp:2091
 msgid "tegen"
 msgstr "opp."
 
-#: ..\src\debug.cpp:2081
+#: ..\src\debug.cpp:2094
 #, c-format
 msgid "schema: %22s"
 msgstr "schema: %22s"
 
-#: ..\src\debug.cpp:2107
+#: ..\src\debug.cpp:2120
 #, c-format
 msgid "Paar %-2u               %2u paren"
 msgstr "Pair %-2u               %2u pairs"
 
-#: ..\src\debug.cpp:2210
+#: ..\src\debug.cpp:2223
 msgid "ronde ->"
 msgstr "round ->"
 
-#: ..\src\debug.cpp:2212
+#: ..\src\debug.cpp:2225
 msgid "tfl"
 msgstr "tbl"
 
-#: ..\src\debug.cpp:2213
+#: ..\src\debug.cpp:2226
 #, c-format
 msgid "%u paren, %u rondes, %u spellen"
 msgstr "%u pairs, %u rounds, %u games"
 
-#: ..\src\debug.cpp:2214
+#: ..\src\debug.cpp:2227
 #, c-format
 msgid "Schema: %s"
 msgstr "Schema: %s"
 
-#: ..\src\debug.cpp:2268
+#: ..\src\debug.cpp:2281
 msgid "Schemaoverzicht"
 msgstr "Schemaoverview"
 
@@ -1443,51 +1438,51 @@ msgstr "s&Witch between datatypes"
 msgid "omschakelen van het ene opslagtype naar het andere"
 msgstr "switch between the two datatypes"
 
-#: ..\src\main.cpp:595
+#: ..\src\main.cpp:594
 msgid "&Taal"
 msgstr "&Language"
 
-#: ..\src\main.cpp:595
+#: ..\src\main.cpp:594
 msgid "taal van de gebruikers interface"
 msgstr "language of the userinterface"
 
-#: ..\src\main.cpp:600
+#: ..\src\main.cpp:597
 msgid "&Systeem info"
 msgstr "&System info"
 
-#: ..\src\main.cpp:600
-msgid "Info over versie van WXwIDGETS"
+#: ..\src\main.cpp:597
+msgid "Info over versie van wxWidgets"
 msgstr "Info about the version of wxWidgets"
 
-#: ..\src\main.cpp:601
+#: ..\src\main.cpp:598
 msgid "&Over "
 msgstr "&About "
 
-#: ..\src\main.cpp:604 ..\src\mylog.cpp:108
+#: ..\src\main.cpp:601 ..\src\mylog.cpp:108
 msgid "&Bestand"
 msgstr "&File"
 
-#: ..\src\main.cpp:605
+#: ..\src\main.cpp:602
 msgid "&Instellingen"
 msgstr "&Settings"
 
-#: ..\src\main.cpp:606
+#: ..\src\main.cpp:603
 msgid "&Scores"
 msgstr "s&Cores"
 
-#: ..\src\main.cpp:607
+#: ..\src\main.cpp:604
 msgid "&Extra"
 msgstr "&Tools"
 
-#: ..\src\main.cpp:608
+#: ..\src\main.cpp:605
 msgid "&Help"
 msgstr "&Help"
 
-#: ..\src\main.cpp:617
+#: ..\src\main.cpp:614
 msgid "Welkom bij "
 msgstr "Welcome at "
 
-#: ..\src\main.cpp:638
+#: ..\src\main.cpp:635
 msgid ""
 "\n"
 "hallo in de console!"
@@ -1495,19 +1490,19 @@ msgstr ""
 "\n"
 "hello in the console!"
 
-#: ..\src\main.cpp:641
+#: ..\src\main.cpp:638
 msgid "Debug active"
 msgstr "Debug active"
 
-#: ..\src\main.cpp:656
+#: ..\src\main.cpp:653
 msgid "PrintPage()"
 msgstr "PrintPage()"
 
-#: ..\src\main.cpp:666
+#: ..\src\main.cpp:663
 msgid ", uit "
 msgstr ", from "
 
-#: ..\src\main.cpp:667
+#: ..\src\main.cpp:664
 #, c-format
 msgid ""
 "\n"
@@ -1528,71 +1523,71 @@ msgstr ""
 "\n"
 "(c) wxSystemInformationFrame, PB: https://github.com/PBfordev"
 
-#: ..\src\main.cpp:674
+#: ..\src\main.cpp:671
 msgid "Over "
 msgstr "About "
 
-#: ..\src\main.cpp:718
+#: ..\src\main.cpp:715
 msgid "MenuNewMatch      := \"bn\"       ; Bestand: Nieuw"
 msgstr "MenuNewMatch      := \"fn\"       ; File: New match/session"
 
-#: ..\src\main.cpp:719
+#: ..\src\main.cpp:716
 msgid "MenuShutdown      := \"ba\"       ; Bestand: Afsluiten"
 msgstr "MenuShutdown      := \"fe\"       ; File: Exit"
 
-#: ..\src\main.cpp:720
+#: ..\src\main.cpp:717
 msgid "MenuPrinter       := \"bp\"       ; Bestand: Printer"
 msgstr "MenuPrinter       := \"fp\"       ; File: Printer choice"
 
-#: ..\src\main.cpp:721
+#: ..\src\main.cpp:718
 msgid "MenuPrintPage     := \"bg\"       ; Bestand: printpaGina"
 msgstr "MenuPrintPage     := \"fg\"       ; File: print paGe"
 
-#: ..\src\main.cpp:722
+#: ..\src\main.cpp:719
 msgid "MenuSetupMatch    := \"iw\"       ; Instellingen: Wedstrijd"
 msgstr "MenuSetupMatch    := \"sm\"       ; Settings: setup Match"
 
-#: ..\src\main.cpp:723
+#: ..\src\main.cpp:720
 msgid "MenuSetupSchema   := \"is\"       ; Instellingen: Schema"
 msgstr "MenuSetupSchema   := \"ss\"       ; Settings: setup Schema"
 
-#: ..\src\main.cpp:724
+#: ..\src\main.cpp:721
 msgid "MenuNamesInit     := \"ii\"       ; Instellingen: Ingeven"
 msgstr "MenuNamesInit     := \"se\"       ; Settings: pairnames Entry/change"
 
-#: ..\src\main.cpp:725
+#: ..\src\main.cpp:722
 msgid "MenuNamesAssign   := \"it\"       ; Instellingen: Toekennen"
 msgstr "MenuNamesAssign   := \"sa\"       ; Settings: pairnames Assignment"
 
-#: ..\src\main.cpp:726
+#: ..\src\main.cpp:723
 msgid "MenuScoreEntry    := \"ss\"       ; Scores: Scores"
 msgstr "MenuScoreEntry    := \"cc\"       ; sCores: sCoreentry"
 
-#: ..\src\main.cpp:727
+#: ..\src\main.cpp:724
 msgid "MenuCorSession    := \"sz\"       ; Scores: Zittingcorrecties"
 msgstr "MenuCorSession    := \"cs\"       ; sCores: entry Sesssioncorrections"
 
-#: ..\src\main.cpp:728
+#: ..\src\main.cpp:725
 msgid "MenuCorEnd        := \"se\"       ; Scores: Eindcorrecties"
 msgstr "MenuCorEnd        := \"ce\"       ; sCores: entry Endcorrections"
 
-#: ..\src\main.cpp:729
+#: ..\src\main.cpp:726
 msgid "MenuResult        := \"su\"       ; Scores: Uitslag"
 msgstr "MenuResult        := \"cr\"       ; sCores: calculation Result"
 
-#: ..\src\main.cpp:730
+#: ..\src\main.cpp:727
 msgid "MenuDbType        := \"ewn\"      ; Extra: Wissel Nieuw"
 msgstr ""
 "MenuDbType        := \"twn\"      ; Tools: sWitch between datatypes: New "
 "datatype"
 
-#: ..\src\main.cpp:731
+#: ..\src\main.cpp:728
 msgid "MenuOldType       := \"ewo\"      ; Extra: Wissel Oud"
 msgstr ""
 "MenuOldType       := \"two\"      ; Tools: sWitch between datatypes: Old "
 "datatype"
 
-#: ..\src\main.cpp:732
+#: ..\src\main.cpp:729
 msgid ""
 "AllMenus          := [\"bn\",\"bp\",\"bg\",\"iw\",\"is\",\"ii\",\"it\","
 "\"ss\",\"sz\",\"se\",\"su\",\"ewo\",\"ewn\"]"
@@ -1600,54 +1595,54 @@ msgstr ""
 "AllMenus          := [\"fn\",\"fp\",\"fg\",\"sm\",\"ss\",\"se\",\"sa\","
 "\"cc\",\"cs\",\"ce\",\"cr\",\"two\",\"twn\"]"
 
-#: ..\src\main.cpp:772
+#: ..\src\main.cpp:769
 #, c-format
 msgid "Menu backup current(%u: %s)"
 msgstr "Menu backup current(%u: %s)"
 
-#: ..\src\main.cpp:783
+#: ..\src\main.cpp:780
 #, c-format
 msgid "Menu old page(%u: %s)"
 msgstr "Menu old page(%u: %s)"
 
-#: ..\src\main.cpp:791
+#: ..\src\main.cpp:788
 #, c-format
 msgid "Menu old show(%u)"
 msgstr "Menu old show(%u)"
 
-#: ..\src\main.cpp:797
+#: ..\src\main.cpp:794
 #, c-format
 msgid "Menu new page(%u)"
 msgstr "Menu new page(%u)"
 
-#: ..\src\main.cpp:840
+#: ..\src\main.cpp:837
 #, c-format
 msgid "OnMenu(%u), id unknown!"
 msgstr "OnMenu(%u), id unknown!"
 
-#: ..\src\main.cpp:844
+#: ..\src\main.cpp:841
 #, c-format
 msgid "Menu new show(%u: %s)"
 msgstr "Menu new show(%u: %s)"
 
-#: ..\src\main.cpp:873
+#: ..\src\main.cpp:870
 msgid "Kies een taal (en start opnieuw op)"
 msgstr "Choose a language (and restart)"
 
-#: ..\src\main.cpp:873
+#: ..\src\main.cpp:870
 msgid "Taalselectie"
 msgstr "Language selection"
 
-#: ..\src\main.cpp:883
+#: ..\src\main.cpp:880
 #, c-format
 msgid "Taalkeuze: id=%d, naam=%s"
 msgstr "Languagechoice: id=%d, name=%s"
 
-#: ..\src\main.cpp:890
+#: ..\src\main.cpp:887
 msgid "Kies een bestand om te printen"
 msgstr "Choose a file for printing"
 
-#: ..\src\main.cpp:894
+#: ..\src\main.cpp:891
 #, c-format
 msgid "Afdrukken van bestand <%s>"
 msgstr "Printing file <%s>"
@@ -1852,23 +1847,18 @@ msgstr "OneNote"
 msgid "Printer %u found, flags: 0x%08x, name: <%s>"
 msgstr "Printer %u found, flags: 0x%08x, name: <%s>"
 
-#: ..\src\printer.cpp:342
+#: ..\src\printer.cpp:350
 msgid "Kan geen bestand naar bestand printen!"
 msgstr "Cant print a file to a file!"
 
-#: ..\src\printer.cpp:674
+#: ..\src\printer.cpp:682
 msgid "MyLinePrinter::EndPrint(): flushing error"
 msgstr "MyLinePrinter::EndPrint(): flushing error"
 
-#: ..\src\printer.cpp:753
+#: ..\src\printer.cpp:761
 #, c-format
 msgid "              blz %d: "
 msgstr "              page %d: "
-
-#: ..\src\printer.cpp:792
-#, c-format
-msgid "MyLinePrinter::PrintCharacter(%c) heeft onverwachte lengte: %d"
-msgstr "MyLinePrinter::PrintCharacter(%c) has unexpected size: %d"
 
 #: ..\src\score.cpp:132 ..\src\score.cpp:172
 msgid "NG"

--- a/release/releasenotes.md
+++ b/release/releasenotes.md
@@ -2,14 +2,18 @@
 
 #V10.1.0  October 25, 2024: bugfixes/extensions/cleanup
 
+#New Features
 - on language change, switch to 'old' page
+- print guides/scoreslips also to file 'list'
+- 'list' is now coded in utf-8 with BOM (was DOS-cp437)
+- adaptation to dpi-changes
+- scoreslips now can have upto 6 games/slip
+
+#Bug fixes
 - better handling of unexpected data when reading schemadata
 - don't display schemadata and prevent unneeded assert's when there is no active schema
 - don't show empty rows for ChoiceMc()
 - don't send selection event for ChoiceMc if clicked on scrollbar-area 
-- print guides/scoreslips also to file 'list'
-- 'list' is now coded in utf-8 with BOM (was DOS-cp437)
-- adaptation to dpi-changes
 
 
 #V10.0.0  September 30, 2024: first release of BridgeWx

--- a/release/releasenotes.md
+++ b/release/releasenotes.md
@@ -1,6 +1,6 @@
 # Releasenotes
 
-V10.1.0  October 25, 2024: bugfixes/extensions/cleanup
+#V10.1.0  October 25, 2024: bugfixes/extensions/cleanup
 
 - on language change, switch to 'old' page
 - better handling of unexpected data when reading schemadata
@@ -10,6 +10,11 @@ V10.1.0  October 25, 2024: bugfixes/extensions/cleanup
 - print guides/scoreslips also to file 'list'
 - 'list' is now coded in utf-8 with BOM (was DOS-cp437)
 - adaptation to dpi-changes
+
+
+#V10.0.0  September 30, 2024: first release of BridgeWx
+
+A simple (windows-only) 'bridge' calculation program
 
 Choose language: menu->extra/taal or menu->tools/language
 

--- a/release/releasenotes.md
+++ b/release/releasenotes.md
@@ -1,8 +1,15 @@
 # Releasenotes
 
-#V10.0.0  September 30, 2024: first release of BridgeWx
+V10.1.0  October 25, 2024: bugfixes/extensions/cleanup
 
-A simple (windows-only) 'bridge' calculation program
+- on language change, switch to 'old' page
+- better handling of unexpected data when reading schemadata
+- don't display schemadata and prevent unneeded assert's when there is no active schema
+- don't show empty rows for ChoiceMc()
+- don't send selection event for ChoiceMc if clicked on scrollbar-area 
+- print guides/scoreslips also to file 'list'
+- 'list' is now coded in utf-8 with BOM (was DOS-cp437)
+- adaptation to dpi-changes
 
 Choose language: menu->extra/taal or menu->tools/language
 

--- a/src/buildDate.h
+++ b/src/buildDate.h
@@ -1,1 +1,1 @@
-static const char* buildDate = "zaterdag 19 oktober 2024 @ 11:52:19";
+static const char* buildDate = "donderdag 24 oktober 2024 @ 16:52:58";

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -427,7 +427,7 @@ Debug::Debug(wxWindow* a_pParent, UINT a_pageId, DebugType a_type) :Baseframe(a_
             AUTOTEST_ADD_WINDOW(m_pGroupChoice, GROUP_CHOICE);
             break;
         case ScoreSlips:
-            m_pTxtCtrlExtra->SetMaxLength(20);
+            m_pTxtCtrlExtra->SetMaxLength(24);
             m_pConsole          ->HideHSizer();
             m_pHsizerGuides     ->Show(false);
             m_pHsizerScoreSlips ->Show(true);
@@ -678,6 +678,7 @@ void MyPrint::EndPage()
 
 void MyPrint::PrintText( const wxPoint& position, const wxString& text)
 {
+    if (text.IsEmpty()) return;
     if (position.y < MY_LINES)
     {
         if (position.y < 0 || position.y >= MY_LINES) return;
@@ -952,7 +953,7 @@ void Debug::RefreshInfo()
 void Debug::InitSlips()
 {
     if (m_debugType != ScoreSlips) return;
-    m_pSetSize      ->Init(4,3,0);      // setsizes from 1-4, default: 4 games/set
+    m_pSetSize      ->Init(6,3,0);      // setsizes from 1-6, default: 4 games/set
     m_pFirstSet     ->Init(24,0,0);     // first set to print from 1-24, default: 1
     m_pNrOfSets     ->Init(24,5,0);     // nr of sets to print from 1-24, default 6
     m_pRepeatCount  ->Init(10,0,0);     // how many times to print all from 1-10, default 1
@@ -1862,156 +1863,142 @@ void Debug::TestSchemas(void)
 
 void Debug::PrintScoreSlips(UINT a_setSize, UINT a_firstSet, UINT a_nrOfSets, UINT a_repeatCount, const wxString& a_extra)
 {
-
+#if 0
+    if (a_setSize > 6)
+    {
+        wxString errorMsg = FMT(_("Set-grootte(%u) is te hoog,\nmaximum is 6"), a_setSize);
+        MyMessageBox(errorMsg,_("Scoreslips"));
+        return;
+    }
+#endif
 /* score slips
                 10   15   20   25   30   35   40   45   50   55   60   65   70   75
-       .1...5....0....5....0....5....0....5....0....5....0....5....0....5....0....5.. V1 V2 V3 V4 V5
-     0 ==============================================================================  |  |  |  |  |
-     1 |                       |      |    Kontrakt     |         |                 |  |  |  |  |  |
-     2 | RONDE :               | Spel |   NZ       OW   |   Res.  | Score NZ + of - |  |  |  |  |  |
-     3 |=======================|======|===========================|=================|  =  |  |  |  | 
-     4 | TAFEL :               |  XX  |*       |*       |         |                 |  3  |  |  |  |
-     5 |=======================|======|========|========|=========|=================|     =  |  |  |
-     6 |    NZ :               |  XX  |*       |*       |         |                 |     5  |  |  |
-     7 |=======================|======|========|========|=========|=================|        =  |  |
-     8 |    OW :               |  XX  |*       |*       |         |                 |        7  |  |
-     9 |=======================|======|========|========|=========|=================|           =  |
-    10 |par.NZ     |par.OW     |  XX  |*       |*       |         |                 |           9  |
-    11 ==============================================================================              =
-       -----H1----->12                                                                            11
-       -----H2----------------->24
-       -----H3------------------------>31
-       -----H4--------------------------------->40
-       -----H5------------------------------------------>49
-       -----H6---------------------------------------------------->59
-       -----H7---------------------------------------------------------------------->77
+       .1...5....0....5....0....5....0....5....0....5....0....5....0....5....0....5.... V1 V2 V3 V4 V5
+     0 ================================================================================  |  |  |  |  |
+     1 |                         |      |    Contract     |         |                 |  |  |  |  |  |
+     2 | ROUND :                 | Game |   NS       EW   |Resultaat| Score NS + or - |  |  |  |  |  |
+     3 |=========================|======|===========================|=================|  =  |  |  |  | 
+     4 | TABLE :                 |  X   |*       |*       |         |                 |  3  |  |  |  |
+     5 |=========================|======|========|========|=========|=================|     =  |  |  |
+     6 |    NS :                 |  X+1 |*       |*       |         |                 |     5  |  |  |
+     7 |=========================|======|========|========|=========|=================|        =  |  |
+     8 |    EW :                 |  X+2 |*       |*       |         |                 |        7  |  |
+     9 |=========================|======|========|========|=========|=================|           =  |
+       ~                         ~      ~        ~        ~         ~                 ~           9  |
+    10 |ini.NS      |ini.EW      | X+N-1|*       |*       |         |                 |              |
+    11 ================================================================================              =
+       -----H1----->13                                                                              11
+       -----H2----------------->26
+       -----H3------------------------>33
+       -----H4--------------------------------->42
+       -----H5------------------------------------------>51
+       -----H6---------------------------------------------------->61
+       -----H7---------------------------------------------------------------------->79
 */
 
     #define ARRAY_LEN(x) (sizeof(x)/sizeof((x)[0]))
 
     #define SL_H0  0    /* SLip position/size H0 etc*/
-    #define SL_H1 12
-    #define SL_H2 24
-    #define SL_H3 31
-    #define SL_H4 40
-    #define SL_H5 49
-    #define SL_H6 59
-    #define SL_H7 77
+    #define SL_H1 13
+    #define SL_H2 26
+    #define SL_H3 33
+    #define SL_H4 42
+    #define SL_H5 51
+    #define SL_H6 61
+    #define SL_H7 79
 
     #define SL_V0 0
     #define SL_V1 3
     #define SL_V2 5
     #define SL_V3 7
     #define SL_V4 9
-    #define SL_V5 11
-
-    prn::table::Line lines[]=
-    {
-          {{SL_H0,SL_V0}, {SL_H7,SL_V0}}    // horizontal lines
-        , {{SL_H0,SL_V1}, {SL_H7,SL_V1}}
-        , {{SL_H0,SL_V2}, {SL_H7,SL_V2}}
-        , {{SL_H0,SL_V3}, {SL_H7,SL_V3}}
-        , {{SL_H0,SL_V4}, {SL_H7,SL_V4}}
-        , {{SL_H0,SL_V5}, {SL_H7,SL_V5}}
-
-        , {{SL_H0,SL_V0}, {SL_H0,SL_V5}}    // vertical lines
-        , {{SL_H2,SL_V0}, {SL_H2,SL_V5}}
-        , {{SL_H3,SL_V0}, {SL_H3,SL_V5}}
-        , {{SL_H5,SL_V0}, {SL_H5,SL_V5}}
-        , {{SL_H6,SL_V0}, {SL_H6,SL_V5}}
-        , {{SL_H7,SL_V0}, {SL_H7,SL_V5}}
-        , {{SL_H1,SL_V4}, {SL_H1,SL_V5}}
-        , {{SL_H4,SL_V1}, {SL_H4,SL_V5}}
-
-    };
-    size_t lineCount = ARRAY_LEN(lines);
-
-    prn::table::Text texts[] =
-    {
-          {{SL_H2+3, SL_V1+1}, ES    }   // 1' game of set  TXT_OFFSET_GAMENR = 0
-        , {{SL_H2+3, SL_V2+1}, ES    }   // 2' game of set
-        , {{SL_H2+3, SL_V3+1}, ES    }   // 3' game of set
-        , {{SL_H2+3, SL_V4+1}, ES    }   // 4' game of set
-
-        , {{SL_H3+1, SL_V1+1}, ES    }   // 1' game vulnerable NS   TXT_OFFSET_VULNERABLE_NS = 4
-        , {{SL_H3+1, SL_V2+1}, ES    }   // 2' game vulnerable NS
-        , {{SL_H3+1, SL_V3+1}, ES    }   // 3' game vulnerable NS
-        , {{SL_H3+1, SL_V4+1}, ES    }   // 4' game vulnerable NS
-
-        , {{SL_H4+1, SL_V1+1}, ES    }   // 1' game vulnerable EW   TXT_OFFSET_VULNERABLE_EW = 8
-        , {{SL_H4+1, SL_V2+1}, ES    }   // 2' game vulnerable EW
-        , {{SL_H4+1, SL_V3+1}, ES    }   // 3' game vulnerable EW
-        , {{SL_H4+1, SL_V4+1}, ES    }   // 4' game vulnerable EW
-
-        , {{SL_H0+2, SL_V0+1}, ES    }   // extra text              TXT_OFFSET_EXTRA
-
-        , {{SL_H0+2, SL_V0+2}, _("RONDE :"    )}
-        , {{SL_H0+2, SL_V1+1}, _("TAFEL :"    )}
-        , {{SL_H0+2, SL_V2+1}, _("   NZ :"    )}
-        , {{SL_H0+2, SL_V3+1}, _("   OW :"    )}
-        , {{SL_H0+1, SL_V4+1}, _("par.NZ"     )}
-        , {{SL_H1+1, SL_V4+1}, _("par.OW"     )}
-        , {{SL_H2+2, SL_V0+2}, _("Spel"       )}
-        , {{SL_H3+4, SL_V0+1}, _("Kontrakt"   )}
-        , {{SL_H3+3, SL_V0+2}, _("NZ       OW")}
-        , {{SL_H5+3, SL_V0+2}, _("Res."       )}
-        , {{SL_H6+2, SL_V0+2}, _("Score NZ + of -")}
-    };
-    size_t textCount = ARRAY_LEN(texts);
-    #define TXT_OFFSET_GAMENR           0   /* index in texts: MUST be correct! */
-    #define TXT_OFFSET_VULNERABLE_NS    4   /* index in texts: MUST be correct! */
-    #define TXT_OFFSET_VULNERABLE_EW    8   /* index in texts: MUST be correct! */
-    #define TXT_OFFSET_EXTRA            12  /* index in texts: MUST be correct  */
-
-    prn::table::TableInfo table =
-    {
-        {2,0},      // start at 2 chars from left-side and first line of page
-        lines,      // set of horizontal lines to draw
-        texts,      // set of texts to print
-        lineCount,  // number of horizontal lines
-        textCount   // number of texts
-    };
+    #define SL_V5 11    /* if 4 or less games else 11 + (games-4)*2  */
 
     UINT firstSet       = a_firstSet;       // input param
     UINT setSize        = a_setSize;        // input param
     UINT nrOfSets       = a_nrOfSets;       // input param
     UINT repeatCount    = a_repeatCount;    // input param
     wxString extra      = a_extra;          // input param
+    
+    int maxVPos         = SL_V5 + (setSize > 4 ? (setSize - 4)*2 : 0);
 
-    if (setSize > 4)
+    prn::table::Line lines[]=
     {
-        wxString errorMsg = FMT(_("Set-grootte(%u) is te hoog,\nmaximum is 4"), setSize);
-        MyMessageBox(errorMsg,_("Scoreslips"));
-        return;
+       {{SL_H0,SL_V0    }, {SL_H0,maxVPos}}
+     , {{SL_H2,SL_V0    }, {SL_H2,maxVPos}}
+     , {{SL_H3,SL_V0    }, {SL_H3,maxVPos}}
+     , {{SL_H5,SL_V0    }, {SL_H5,maxVPos}}
+     , {{SL_H6,SL_V0    }, {SL_H6,maxVPos}}
+     , {{SL_H7,SL_V0    }, {SL_H7,maxVPos}}
+     , {{SL_H4,SL_V1    }, {SL_H4,maxVPos}}
+     , {{SL_H1,maxVPos-2}, {SL_H1,maxVPos}} // last line with initials
+    };
+    size_t lineCount = ARRAY_LEN(lines);
+
+    prn::table::Text texts[] =
+    {
+          {{SL_H0+2, SL_V0+1}  , extra           }    // extra text
+        , {{SL_H0+2, SL_V0+2}  , _("RONDE :"    )}
+        , {{SL_H0+2, SL_V1+1}  , _("TAFEL :"    )}
+        , {{SL_H0+2, SL_V2+1}  , _("   NZ :"    )}
+        , {{SL_H0+2, SL_V3+1}  , _("   OW :"    )}
+        , {{SL_H0+1, maxVPos-1}, _("par.NZ"     )}
+        , {{SL_H1+1, maxVPos-1}, _("par.OW"     )}
+        , {{SL_H2+2, SL_V0+2}  , _("Spel"       )}
+        , {{SL_H3+4, SL_V0+1}  , _("Kontrakt"   )}
+        , {{SL_H3+3, SL_V0+2}  , _("NZ       OW")}
+        , {{SL_H5+1, SL_V0+2}  , _("Resultaat"  )}
+        , {{SL_H6+2, SL_V0+2}  , _("Score NZ + of -")}
+    };
+    size_t textCount = ARRAY_LEN(texts);
+
+    prn::table::TableInfo table =
+    {
+        {2,0},      // start at 2 chars from left-side and first line of page
+        lines,      // set of (static) H+V Lines to draw
+        texts,      // set of texts to print
+        lineCount,  // number of (static) lines
+        textCount   // number of (static) texts
+    };
+
+    UINT nrOfHLines = 6 + (a_setSize > 4 ? a_setSize - 4 : 0);
+    table.linesV.reserve(nrOfHLines);
+    table.textsV.reserve(setSize*(size_t)3);
+    int vPos = SL_V0;
+    for (UINT hLine = 0; hLine < nrOfHLines; ++hLine)
+    {
+        table.linesV.push_back({ {SL_H0,vPos} , {SL_H7,vPos} });
+        vPos += (vPos == SL_V0) ? 3 : 2;
     }
-    int originY = table.origin.y;   // needed(?) when starting new-page
+
+    int originY = table.origin.y;   // needed when starting new-page
 
     MyPrint myPrint(m_bPrintNext ? nullptr : &m_consoleOutput); // zero: no screen output, only real print, non-zero: only output to wxArrayString a_pTextOutput
 
     myPrint.BeginPrint(_("Scoreslips"));
-
     for (; repeatCount; --repeatCount)
     {
         UINT firstGame    = (firstSet - 1)*setSize + 1;
         UINT linesPrinted = 0;
         for (UINT slips = 1 ; slips <= nrOfSets; ++slips)
         {
-            texts[TXT_OFFSET_EXTRA].text = extra;
-            for (UINT game = 0; game < setSize ; ++game)
+            table.textsV.clear();
+            vPos = SL_V1+1;
+            for (UINT game = 0; game < setSize ; ++game, vPos += 2)
             {
-                texts[TXT_OFFSET_GAMENR        + game].text = FMT("%2u", game + firstGame);
-                texts[TXT_OFFSET_VULNERABLE_NS + game].text = score::VulnerableChar(game + firstGame, true );
-                texts[TXT_OFFSET_VULNERABLE_EW + game].text = score::VulnerableChar(game + firstGame, false);
+                table.textsV.push_back( {{SL_H2+3, vPos}, FMT("%2u", game + firstGame)                   } );
+                table.textsV.push_back( {{SL_H3+1, vPos}, score::VulnerableChar(game + firstGame, true ) } );
+                table.textsV.push_back( {{SL_H4+1, vPos}, score::VulnerableChar(game + firstGame, false) } );
             }
-            if (linesPrinted + SL_V5 >= prn::GetLinesPerPage())
+            if (linesPrinted + maxVPos >= prn::GetLinesPerPage())
             {
                 linesPrinted   = 0;
                 table.origin.y = originY;
                 myPrint.EndPage();              // force new page
             }
             myPrint.PrintTable(table);          // 1 slip
-            table.origin.y += SL_V5+3;
-            linesPrinted   += SL_V5+3;
+            table.origin.y += maxVPos+3;
+            linesPrinted   += maxVPos+3;
             firstGame      += setSize;
         }   // end slips
         table.origin.y = originY;
@@ -2036,15 +2023,15 @@ void Debug::PrintGuideNew(UINT a_pair)
       0 ds Janssen - Pietersen                    |  |  |  |
       1 extra info................extra      .    |  |  |  |
       2 ==================================   .    =  |  |  |
-      3 | Paar 13               14 paren |   .    2  |  |  |
+      3 | Pair 13               14 pairs |   .    2  |  |  |
       4 | schema:               4stayr14 |   .       |  |  |
       5 |================================|   .       =  |  |
-      6 |ronde| tafel |tegen|  spellen   |   .       5  |  |
+      6 |round| table |opp. |  games     |   .       5  |  |
       7 |================================|   .          =  |
-      8 |  1  |  7 NZ |   6 |  9 - 12  L3|   .          7  |
-      . |  2  |  2 OW |   8 |  5 - 8     |   .             |
+      8 |  1  |  7 NS |   6 |  9 - 12  B3|   .          7  |
+      . |  2  |  2 EW |   8 |  5 - 8     |   .             |
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                 |
-      . |  N  |  7 NZ |   2 | 13 - 16  L4|   .             |
+      . |  N  |  7 NS |   2 | 13 - 16  B4|   .             |
       . ==================================   .             =
                                                          7+N+1  where N = number of rounds
       . .   .   .   .   .   .   .   .   .   .
@@ -2182,14 +2169,14 @@ void Debug::PrintSchemaOverviewNew()
                  5   10   15   20   25   30   35   40   45   50   55   60
             0....5....0....5....0....5....0....5....0....5....0....5....0.        V1 V2 V3  Vn
             ╔════════════════════════════════════════════════════════════╗  0      |  |  |   |
-            ║14 paren, 6 rondes, 24 spellen                              ║  1      |  |  |   |
+            ║14 pairs, 6 rounds, 24 games                                ║  1      |  |  |   |
             ║Schema: 6multi14                                            ║  2      |  |  |   |
             ╠════════════╦═══════════════════════════════════════════════╣  3      =  |  |   |
-            ║            ║ ronde ->                                      ║  4      3  |  |   |
+            ║            ║ round ->                                      ║  4      3  |  |   |
             ╠════════╦═══╬═══════╦═══════╦═══════╦═══════╦═══════╦═══════╣  5         =  |   |
-            ║spellen ║tfl║   1   ║   2   ║   3   ║   4   ║   5   ║   6   ║  6 DV      5  |   |
+            ║games   ║tbl║   1   ║   2   ║   3   ║   4   ║   5   ║   6   ║  6 DV      5  |   |
             ╠════════╬═══╬═══════╬═══════╬═══════╬═══════╬═══════╬═══════╣  7  =         =   |
-            ║A:  1-4 ║ 1 ║   1-2)║   6-11║   8-3 ║   5-4 ║D: 5-12║   9-12║  8  |         7   |
+            ║A:  1-4 ║ 1 ║   1-2 ║   6-11║   8-3 ║   5-4 ║D: 5-12║   9-12║  8  |         7   |
             ╠════════╬═══╬═══════╬═══════╬═══════╬═══════╬═══════╬═══════╣  9  =             |
             ║B:  5-8 ║ 2 ║   3-4 ║  12-7 ║   6-9 ║  11-13║   1-8 ║   5-2 ║     2             |
                                                                                              .

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -425,7 +425,7 @@ void MyApp::ReInitLanguage()
 
     const wxLanguageInfo* const langInfo = wxUILocale::GetLanguageInfo(wxLANGUAGE_DEFAULT);
     if (langInfo)
-        MyLogMessage(_("Systeemtaal: %d, %s"), langInfo->Language, langInfo->Description);
+        MyLogMessage(_("Systeemtaal: id=%d, %s"), langInfo->Language, langInfo->Description);
     else
         MyLogMessage(_("Systeemtaal: de default systeem taal"));
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -530,9 +530,9 @@ MyFrame::MyFrame(MyApp& a_theApp) : wxFrame(nullptr, wxID_ANY, ssWinTitle = _("B
         vSize = (vSize *(100+fontIncrease)+50)/100;
         vSize = std::min(vSize,maxY);
 
-     hSize = HSIZE_WANTED;
-     vSize = VSIZE_WANTED;
-     SetSize({hSize,vSize});
+    hSize = FromDIP(HSIZE_WANTED);
+    vSize = FromDIP(VSIZE_WANTED);
+    SetSize({hSize,vSize});
 
     static wxPoint pos{ {0,0} };
     if (pos == wxPoint({0, 0})) pos = GetPosition();    // use same position after language change
@@ -591,13 +591,10 @@ MyFrame::MyFrame(MyApp& a_theApp) : wxFrame(nullptr, wxID_ANY, ssWinTitle = _("B
     otherDb->AppendRadioItem(ID_MENU_OLD_DBASE, _("&Oud bestandstype (.ini)"    ), _("Gebruik van 'oude' .ini/data bestanden voor opslag"     ));
     otherDb->AppendRadioItem(ID_MENU_NEW_DBASE, _("&Nieuw bestandstype (.db)"   ), _("Gebruik van nieuw .db bestand voor opslag"         ));
     menuExtra->AppendSubMenu(otherDb          , _("&Wissel van bestandstype"    ), _("omschakelen van het ene opslagtype naar het andere"));
-
     menuExtra->Append(ID_MENU_LANGUAGE        , _("&Taal"                       ), _("taal van de gebruikers interface"));
 
-
-
     wxMenu *menuHelp = new wxMenu;
-    menuHelp->Append(ID_SYSTEM_INFO         , _("&Systeem info"                 ), _("Info over versie van WXwIDGETS"));
+    menuHelp->Append(ID_SYSTEM_INFO         , _("&Systeem info"                 ), _("Info over versie van wxWidgets"));
     menuHelp->Append(ID_ABOUT               , _("&Over ") + __PRG_NAME__ );
  
     m_pMenuBar = new wxMenuBar;

--- a/src/printer.cpp
+++ b/src/printer.cpp
@@ -924,12 +924,14 @@ void MyLinePrinter::PrintTable(const table::TableInfo& table)
     {   // print all the texts in the textarray
         wxPoint  pos  = table.texts[index].begin + table.origin;
         wxString text = table.texts[index].text;
+        if (text.IsEmpty()) continue;
         (void)TextOut(m_hPrinter, X(pos.x), Y(pos.y), text.c_str(), text.Len());
     }
     for (const auto& textIt : table.textsV)
     {   // print all the texts in the textvector
         wxPoint  pos  = textIt.begin + table.origin;
         wxString text = textIt.text;
+        if (text.IsEmpty()) continue;
         (void)TextOut(m_hPrinter, X(pos.x), Y(pos.y), text.c_str(), text.Len());
     }
 

--- a/src/printer.h
+++ b/src/printer.h
@@ -30,6 +30,7 @@ namespace table
 {   //simple table-printing: texts and horizontal/vertical lines
 struct Line
 {
+    Line() { begin = { 0,0 }; end = { 0,0 }; }
     Line(const wxPoint& a_begin, const wxPoint& a_end){begin = a_begin; end = a_end;}
     wxPoint     begin;          // beginpoint in chars/lines from left-top of page
     wxPoint     end;            // endpoint of line

--- a/src/version.h
+++ b/src/version.h
@@ -2,14 +2,14 @@
 // Distributed under the MIT License (http://opensource.org/licenses/MIT)
 
 #define __PRG_NAME__            "BridgeWx"
-#define __VERSION__             "v10.0.99"        // like "v2.00"
+#define __VERSION__             "v10.1.0"           /* like "v2.0.0" */
 #define __VERSION_MAIN__        "v10"
-#define __VERSION_NR__          10,0,0,99
-#define __PRODUCT_VERSION__     10,0,0,99
+#define __VERSION_NR__          10,1,0,0
+#define __PRODUCT_VERSION__     10,1,0,0
 #define __YEAR__                "2024"
 
-#define __VERSION__AUTO         "x9.99"             // simulated version in autotest: less differences in output files
-#define __YEAR__AUTO            "2024"              // simulated year in autotest: less differences in output files
-#define __DATE__AUTO            _("1 januari 2024") // simulated date in autotest: less differences in output files
-#define __TIME__AUTO            "12:00:00"          // simulated time
-#define __DAY__AUTO             _("maandag")        // simulated day
+#define __VERSION__AUTO         "x9.99"             /* simulated version in autotest: less differences in output files */
+#define __YEAR__AUTO            "2024"              /* simulated year in autotest: less differences in output files */
+#define __DATE__AUTO            _("1 januari 2024") /* simulated date in autotest: less differences in output files */
+#define __TIME__AUTO            "12:00:00"          /* simulated time*/
+#define __DAY__AUTO             _("maandag")        /* simulated day */


### PR DESCRIPTION
#New Features 
- on language change, switch to 'old' page
- print guides/scoreslips also to file 'list'
- 'list' is now coded in utf-8 with BOM (was DOS-cp437) 
- adaptation to dpi-changes
- scoreslips now can have upto 6 games/slip

#Bug fixes 
- better handling of unexpected data when reading schemadata
- don't display schemadata and prevent unneeded assert's when there is no active schema 
- don't show empty rows for ChoiceMc()
- don't send selection event for ChoiceMc if clicked on scrollbar-area
