### PR TITLE
Bug fixing and score-entry through textual contract

### DIFF
--- a/autotest/ref_autoTest01.db.en
+++ b/autotest/ref_autoTest01.db.en
@@ -3,7 +3,7 @@
 ;info database           : 'data saved according definition of version <x>'
 ;info pair names         : '<global pairnr> = {<name>,<clubId>}, max size=30'
 ;info club names         : '<club id> = "club name", max size=25'
-;info game result        : '<game nr> = {<ns>,<ew>,<ns result>,<ew result>}[@ ...]'
+;info game result        : '<game nr> = {<ns>,<ew>,<ns result>,<ew result>[,"ns contract","ew contract"]}[@ ...]'
 ;info schema             : '{<nr of games>,<setsize>,<first game>}@{<nr of pairs>,<absent pair>,"schema","groupChars"}[@...]'
 ;info min/max club       : '{<min pairs needed>,<max pairs used>}'
 ;info assignments        : '<global pairnr>[@...] -> array[<sessionpair>] = <global pairnr>'

--- a/autotest/ref_autoTest01.db.en.butler
+++ b/autotest/ref_autoTest01.db.en.butler
@@ -3,7 +3,7 @@
 ;info database           : 'data saved according definition of version <x>'
 ;info pair names         : '<global pairnr> = {<name>,<clubId>}, max size=30'
 ;info club names         : '<club id> = "club name", max size=25'
-;info game result        : '<game nr> = {<ns>,<ew>,<ns result>,<ew result>}[@ ...]'
+;info game result        : '<game nr> = {<ns>,<ew>,<ns result>,<ew result>[,"ns contract","ew contract"]}[@ ...]'
 ;info schema             : '{<nr of games>,<setsize>,<first game>}@{<nr of pairs>,<absent pair>,"schema","groupChars"}[@...]'
 ;info min/max club       : '{<min pairs needed>,<max pairs used>}'
 ;info assignments        : '<global pairnr>[@...] -> array[<sessionpair>] = <global pairnr>'

--- a/autotest/ref_autoTest01.db.nl
+++ b/autotest/ref_autoTest01.db.nl
@@ -3,7 +3,7 @@
 ;info database           : 'data saved according definition of version <x>'
 ;info pair names         : '<global pairnr> = {<name>,<clubId>}, max size=30'
 ;info club names         : '<club id> = "club name", max size=25'
-;info game result        : '<game nr> = {<ns>,<ew>,<ns result>,<ew result>}[@ ...]'
+;info game result        : '<game nr> = {<ns>,<ew>,<ns result>,<ew result>[,"ns contract","ew contract"]}[@ ...]'
 ;info schema             : '{<nr of games>,<setsize>,<first game>}@{<nr of pairs>,<absent pair>,"schema","groupChars"}[@...]'
 ;info min/max club       : '{<min pairs needed>,<max pairs used>}'
 ;info assignments        : '<global pairnr>[@...] -> array[<sessionpair>] = <global pairnr>'

--- a/autotest/ref_autoTest01.db.nl.butler
+++ b/autotest/ref_autoTest01.db.nl.butler
@@ -3,7 +3,7 @@
 ;info database           : 'data saved according definition of version <x>'
 ;info pair names         : '<global pairnr> = {<name>,<clubId>}, max size=30'
 ;info club names         : '<club id> = "club name", max size=25'
-;info game result        : '<game nr> = {<ns>,<ew>,<ns result>,<ew result>}[@ ...]'
+;info game result        : '<game nr> = {<ns>,<ew>,<ns result>,<ew result>[,"ns contract","ew contract"]}[@ ...]'
 ;info schema             : '{<nr of games>,<setsize>,<first game>}@{<nr of pairs>,<absent pair>,"schema","groupChars"}[@...]'
 ;info min/max club       : '{<min pairs needed>,<max pairs used>}'
 ;info assignments        : '<global pairnr>[@...] -> array[<sessionpair>] = <global pairnr>'

--- a/autotest/ref_list.en
+++ b/autotest/ref_list.en
@@ -606,9 +606,9 @@ Group-result of match '<auto-test, session 1>', session 1
 
 (c)opyright 1991-2024 hl/tc, monday januari 1 2024 12:00:00
 
-Total result
+Final result
 <auto-test, session 1>
-Total result
+Final result
 
 rank pairname                         S1      total   avg.  A B
    1 pair 15  . . . . . . . . . . .  72.77    72.77  72.77  . 1
@@ -2501,9 +2501,9 @@ Group-result of match '<auto-test, session 2>', session 2
 
 (c)opyright 1991-2024 hl/tc, monday januari 1 2024 12:00:00
 
-Total result
+Final result
 <auto-test, session 2>
-Total result
+Final result
 
 rank pairname                         S1     S2      total   avg.  A B
    1 pair 3 . . . . . . . . . . . .  64.59  62.24   126.83  63.42  1 .
@@ -4398,9 +4398,9 @@ Group-result of match '<auto-test, session 3>', session 3
 
 (c)opyright 1991-2024 hl/tc, monday januari 1 2024 12:00:00
 
-Total result
+Final result
 <auto-test, session 3>
-Total result
+Final result
 
 rank pairname                         S1     S2     S3      total   avg.  A B
    1 pair 11  . . . . . . . . . . .  56.10  64.54  62.24   182.88  60.96  1 .

--- a/autotest/ref_list.en.butler
+++ b/autotest/ref_list.en.butler
@@ -693,9 +693,9 @@ Group-result of match '<auto-test, session 1>', session 1
 
 (c)opyright 1991-2024 hl/tc, monday januari 1 2024 12:00:00
 
-Total result
+Final result
 <auto-test, session 1>
-Total result
+Final result
 
 rank pairname                         S1      total   avg.  A B
    1 pair 2 . . . . . . . . . . . .   4.00     4.00   4.00  1 .
@@ -2672,9 +2672,9 @@ Group-result of match '<auto-test, session 2>', session 2
 
 (c)opyright 1991-2024 hl/tc, monday januari 1 2024 12:00:00
 
-Total result
+Final result
 <auto-test, session 2>
-Total result
+Final result
 
 rank pairname                         S1     S2      total   avg.  A B
    1 pair 3 . . . . . . . . . . . .   3.54   1.32     4.86   2.43  1 .
@@ -4653,9 +4653,9 @@ Group-result of match '<auto-test, session 3>', session 3
 
 (c)opyright 1991-2024 hl/tc, monday januari 1 2024 12:00:00
 
-Total result
+Final result
 <auto-test, session 3>
-Total result
+Final result
 
 rank pairname                         S1     S2     S3      total   avg.  A B
    1 pair 1 . . . . . . . . . . . .   1.22   3.18   3.18     7.58   2.53  1 .

--- a/locales/nl.po
+++ b/locales/nl.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: BridgeWx\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-27 18:42+0100\n"
-"PO-Revision-Date: 2025-03-27 18:43+0100\n"
+"POT-Creation-Date: 2025-03-29 16:26+0100\n"
+"PO-Revision-Date: 2025-03-29 16:27+0100\n"
 "Last-Translator: BusyHarry\n"
 "Language-Team: \n"
 "Language: nl\n"
@@ -118,52 +118,52 @@ msgstr ""
 "\n"
 "Paar naam"
 
-#: ..\src\baseframe.cpp:78
+#: ..\src\baseframe.cpp:79
 #, c-format
 msgid "Baseframe:: row %d, column %d changes from <%s> to <%s>"
 msgstr "Baseframe:: rij %d, kolom %d verandert van <%s> in <%s>"
 
-#: ..\src\baseframe.cpp:93 ..\src\debug.cpp:124
+#: ..\src\baseframe.cpp:94 ..\src\debug.cpp:124
 msgid "Save"
 msgstr "Opslaan"
 
-#: ..\src\baseframe.cpp:94
+#: ..\src\baseframe.cpp:95
 msgid "save changed data"
 msgstr "gewijzigde data opslaan"
 
-#: ..\src\baseframe.cpp:95
+#: ..\src\baseframe.cpp:96
 msgid "Undo"
 msgstr "Herstel"
 
-#: ..\src\baseframe.cpp:96
+#: ..\src\baseframe.cpp:97
 msgid "undo changes"
 msgstr "wijzigingen terugdraaien"
 
-#: ..\src\baseframe.cpp:126
+#: ..\src\baseframe.cpp:127
 msgid "OnCancel()"
 msgstr "OnCancel()"
 
-#: ..\src\baseframe.cpp:156
+#: ..\src\baseframe.cpp:157
 msgid "Search"
 msgstr "Zoek"
 
-#: ..\src\baseframe.cpp:157
+#: ..\src\baseframe.cpp:158
 msgid "Text to search:"
 msgstr "Te zoeken tekst:"
 
-#: ..\src\baseframe.cpp:755
+#: ..\src\baseframe.cpp:756
 msgid "Ok"
 msgstr "Ok"
 
-#: ..\src\baseframe.cpp:756
+#: ..\src\baseframe.cpp:757
 msgid "Yes"
 msgstr "Ja"
 
-#: ..\src\baseframe.cpp:757
+#: ..\src\baseframe.cpp:758
 msgid "No"
 msgstr "Nee"
 
-#: ..\src\baseframe.cpp:758
+#: ..\src\baseframe.cpp:759
 msgid "Cancel"
 msgstr "Afbreken"
 
@@ -766,8 +766,12 @@ msgid "Database version error, expected <= %ld, found %ld"
 msgstr "Database versie error, verwacht <= %ld, aanwezig %ld"
 
 #: ..\src\database.cpp:155
-msgid ": is not accessable!"
-msgstr ": is niet toegankelijk!"
+msgid ""
+": is not accessable!\n"
+"Path set to: "
+msgstr ""
+": is niet toegankelijk!\n"
+"Opslaglocatie nu in map: "
 
 #: ..\src\database.cpp:218
 #, c-format

--- a/locales/nl.po
+++ b/locales/nl.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: BridgeWx\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-29 16:26+0100\n"
-"PO-Revision-Date: 2025-03-29 16:27+0100\n"
+"POT-Creation-Date: 2025-03-30 17:37+0200\n"
+"PO-Revision-Date: 2025-03-30 17:38+0200\n"
 "Last-Translator: BusyHarry\n"
 "Language-Team: \n"
 "Language: nl\n"
@@ -195,7 +195,7 @@ msgstr "Paar:"
 msgid "Result per pair"
 msgstr "Uitslag per paar"
 
-#: ..\src\calcScore.cpp:178 ..\src\scoreEntry.cpp:88
+#: ..\src\calcScore.cpp:178 ..\src\scoreEntry.cpp:91
 msgid "Game:"
 msgstr "Spel:"
 
@@ -247,7 +247,7 @@ msgstr "frequentiestaten"
 msgid "group"
 msgstr "groep"
 
-#: ..\src\calcScore.cpp:289 ..\src\main.cpp:745
+#: ..\src\calcScore.cpp:289 ..\src\main.cpp:746
 msgid "session"
 msgstr "zitting"
 
@@ -267,7 +267,7 @@ msgstr "club zitting"
 msgid "club total"
 msgstr "club totaal"
 
-#: ..\src\calcScore.cpp:334 ..\src\main.cpp:932
+#: ..\src\calcScore.cpp:334 ..\src\main.cpp:933
 msgid "Error"
 msgstr "Error"
 
@@ -355,7 +355,7 @@ msgstr "uitslag"
 msgid "Pair '%s' has played, but was NOT assigned to a global name"
 msgstr "Paar '%s' heeft gespeeld, maar is nog niet gekoppeld aan een globale paarnaam"
 
-#: ..\src\calcScore.cpp:1089 ..\src\scoreEntry.cpp:493 ..\src\setupGame.cpp:209
+#: ..\src\calcScore.cpp:1089 ..\src\scoreEntry.cpp:553 ..\src\setupGame.cpp:209
 #: ..\src\setupSchema.cpp:269
 msgid "Warning"
 msgstr "Waarschuwing"
@@ -466,11 +466,11 @@ msgstr "Spel %2u: "
 msgid "not played"
 msgstr "niet gespeeld"
 
-#: ..\src\calcScore.cpp:1576 ..\src\debug.cpp:1030 ..\src\debug.cpp:1865
+#: ..\src\calcScore.cpp:1576 ..\src\debug.cpp:1024 ..\src\debug.cpp:1711
 msgid "EW"
 msgstr "OW"
 
-#: ..\src\calcScore.cpp:1576 ..\src\debug.cpp:1030 ..\src\debug.cpp:1865
+#: ..\src\calcScore.cpp:1576 ..\src\debug.cpp:1024 ..\src\debug.cpp:1711
 msgid "NS"
 msgstr "NZ"
 
@@ -586,7 +586,7 @@ msgstr "Fout in parameter: "
 msgid " of "
 msgstr " van "
 
-#: ..\src\cfg.cpp:909 ..\src\main.cpp:670
+#: ..\src\cfg.cpp:909 ..\src\main.cpp:671
 msgid ", version "
 msgstr ", versie "
 
@@ -655,7 +655,7 @@ msgid "ChoiceMC::SetPopupWidth() size=%i, columns=%u, width=%i"
 msgstr "ChoiceMC::SetPopupWidth() size=%i, colommen=%u, breedte=%i"
 
 #: ..\src\correctionsEnd.cpp:35 ..\src\correctionsSession.cpp:48
-#: ..\src\main.cpp:746
+#: ..\src\main.cpp:747
 msgid "pair"
 msgstr "paar"
 
@@ -664,7 +664,7 @@ msgid "bonus"
 msgstr "bonus"
 
 #: ..\src\correctionsEnd.cpp:39 ..\src\correctionsSession.cpp:54
-#: ..\src\debug.cpp:2090 ..\src\debug.cpp:2222
+#: ..\src\debug.cpp:1936 ..\src\debug.cpp:2068
 msgid "games"
 msgstr "spellen"
 
@@ -793,22 +793,22 @@ msgstr "Inlezen clubnamen: clubnr <%u> te groot!"
 msgid "Rading clubnames: <%s = %s> invalid!"
 msgstr "Inlezen clubnamen: <%s = %s> ongeldig!"
 
-#: ..\src\database.cpp:296
+#: ..\src\database.cpp:307
 #, c-format
 msgid "Reading scores: gamenr <%s> too high!"
 msgstr "Inlezen scores: spelnr <%s> te groot!"
 
-#: ..\src\database.cpp:307
+#: ..\src\database.cpp:328
 #, c-format
 msgid "Reading scores: game %u: <%s> invalid!"
 msgstr "Inlezen scores: spel %u: <%s> ongeldig!"
 
-#: ..\src\database.cpp:447 ..\src\database.cpp:473
+#: ..\src\database.cpp:471 ..\src\database.cpp:497
 #, c-format
 msgid "Error while reading schema <%s>"
 msgstr "Fout bij inlezen schema <%s>"
 
-#: ..\src\database.cpp:761
+#: ..\src\database.cpp:785
 #, c-format
 msgid ""
 " Error in database <%s> value in key <%s>: <%i> higher then max <%u>\n"
@@ -817,7 +817,7 @@ msgstr ""
 " Fout in database <%s> waarde in sleutel '%s': '%i' groter dan max '%u'\n"
 "Wordt genegeerd."
 
-#: ..\src\database.cpp:765
+#: ..\src\database.cpp:789
 msgid "database error"
 msgstr "database fout"
 
@@ -938,7 +938,7 @@ msgstr "Debug console"
 msgid "Creation/print of guides"
 msgstr "Aanmaak/printen van gidsbriefjes"
 
-#: ..\src\debug.cpp:429 ..\src\debug.cpp:2110
+#: ..\src\debug.cpp:429 ..\src\debug.cpp:1956
 msgid "Guides"
 msgstr "Gidsbriefjes"
 
@@ -946,11 +946,11 @@ msgstr "Gidsbriefjes"
 msgid "Creation/print of scoreslips"
 msgstr "Aanmaak/printen van scoreslips"
 
-#: ..\src\debug.cpp:442 ..\src\debug.cpp:1880 ..\src\debug.cpp:1989
+#: ..\src\debug.cpp:442 ..\src\debug.cpp:1726 ..\src\debug.cpp:1835
 msgid "Scoreslips"
 msgstr "Scoreslips"
 
-#: ..\src\debug.cpp:527 ..\src\debug.cpp:1224 ..\src\debug.cpp:1676
+#: ..\src\debug.cpp:527 ..\src\debug.cpp:1218 ..\src\debug.cpp:1522
 msgid "No schema available for these data"
 msgstr "Geen schema voorhanden"
 
@@ -958,31 +958,31 @@ msgstr "Geen schema voorhanden"
 msgid "debug window of "
 msgstr "debug window van "
 
-#: ..\src\debug.cpp:875
+#: ..\src\debug.cpp:869
 msgid "     ----> round error <---, default round 1\n"
 msgstr "     ----> ronde fout <---, default ronde 1\n"
 
-#: ..\src\debug.cpp:888
+#: ..\src\debug.cpp:882
 msgid "     ----> pair error <---, default pair 1\n"
 msgstr "     ----> paar fout <---, default paar 1\n"
 
-#: ..\src\debug.cpp:899 ..\src\debug.cpp:1381
+#: ..\src\debug.cpp:893 ..\src\debug.cpp:1375
 msgid "     ----> group error <---, default group 1\n"
 msgstr "     ----> groep fout <---, default groep 1\n"
 
-#: ..\src\debug.cpp:910
+#: ..\src\debug.cpp:904
 msgid "     ----> table error <---\n"
 msgstr "     ----> tafel fout <---\n"
 
-#: ..\src\debug.cpp:921
+#: ..\src\debug.cpp:915
 msgid "     ----> game error <---, default game 1\n"
 msgstr "     ----> spel fout <---, default spel 1\n"
 
-#: ..\src\debug.cpp:930
+#: ..\src\debug.cpp:924
 msgid "group "
 msgstr "groep "
 
-#: ..\src\debug.cpp:941
+#: ..\src\debug.cpp:935
 #, c-format
 msgid ""
 "\n"
@@ -991,165 +991,132 @@ msgstr ""
 "\n"
 "test-mode, groep %u (%u)\n"
 
-#: ..\src\debug.cpp:986
+#: ..\src\debug.cpp:980
 msgid "all"
 msgstr "alle"
 
 #. TRANSLATORS: 'B' -> table to 'B'orrow games from (same games on different tables)
-#: ..\src\debug.cpp:1062
+#: ..\src\debug.cpp:1056
 #, c-format
 msgid "B%u"
 msgstr "L%u"
 
-#: ..\src\debug.cpp:1096
+#: ..\src\debug.cpp:1090
 msgid "any text above each schema:"
 msgstr "eventuele tekst boven ieder schema:"
 
-#: ..\src\debug.cpp:1235
+#: ..\src\debug.cpp:1229
 #, c-format
 msgid "pair %u, round %u, table %u, direction %s, games %s, opponent %u\n"
 msgstr "paar %u, ronde %u, tafel %u, richting %s, spellen %s, tegenpaar %u\n"
 
-#: ..\src\debug.cpp:1243
+#: ..\src\debug.cpp:1237
 #, c-format
 msgid "pair %u, game %u:\n"
 msgstr "paar %u, spel %u:\n"
 
-#: ..\src\debug.cpp:1249
+#: ..\src\debug.cpp:1243
 #, c-format
 msgid "pair %u, games %s, table %u, direction %s, round %u, opponent %u\n"
 msgstr "paar %u, spellen %s, tafel %u, richting %s, ronde %u, tegenpaar %u\n"
 
-#: ..\src\debug.cpp:1257
+#: ..\src\debug.cpp:1251
 #, c-format
 msgid "pair %u, table %u:\n"
 msgstr "paar %u, tafel %u:\n"
 
-#: ..\src\debug.cpp:1261
+#: ..\src\debug.cpp:1255
 #, c-format
 msgid "pair %u, table %u, round %u, direction %s, games %s, opponent %u\n"
 msgstr "paar %u, tafel %u, ronde %u, richting %s, spellen %s, tegenpaar %u\n"
 
-#: ..\src\debug.cpp:1269
+#: ..\src\debug.cpp:1263
 #, c-format
 msgid "Round %u:\n"
 msgstr "Ronde %u:\n"
 
-#: ..\src\debug.cpp:1273
+#: ..\src\debug.cpp:1267
 #, c-format
 msgid "pair %2u, direction %s, table %2u, games %s\n"
 msgstr "paar %2u, richting %s, tafel %2u, spellen %s\n"
 
-#: ..\src\debug.cpp:1280
+#: ..\src\debug.cpp:1274
 #, c-format
 msgid "Round %u, game %u:\n"
 msgstr "Ronde %u, spel %u:\n"
 
-#: ..\src\debug.cpp:1291
+#: ..\src\debug.cpp:1285
 #, c-format
 msgid "round %u, games %s, pair %2u, direction %s, table %u\n"
 msgstr "ronde %u, spellen %s, paar %2u, richting %s, tafel %u\n"
 
-#: ..\src\debug.cpp:1300
+#: ..\src\debug.cpp:1294
 #, c-format
 msgid "games %s are not played in round %u\n"
 msgstr "spellen %s worden in ronde %u niet gespeeld\n"
 
-#: ..\src\debug.cpp:1305
+#: ..\src\debug.cpp:1299
 #, c-format
 msgid "Round %u, table %u:\n"
 msgstr "Ronde %u, tafel %u:\n"
 
-#: ..\src\debug.cpp:1309
+#: ..\src\debug.cpp:1303
 #, c-format
 msgid "round %u, table %u, games %s, pairs %u (NS) + %u (EW)\n"
 msgstr "ronde %u, tafel %u, spellen %s, paren %u (NZ) + %u (OW)\n"
 
-#: ..\src\debug.cpp:1316
+#: ..\src\debug.cpp:1310
 #, c-format
 msgid "Game %u:\n"
 msgstr "Spel %u:\n"
 
-#: ..\src\debug.cpp:1325
+#: ..\src\debug.cpp:1319
 #, c-format
 msgid "round %u, table %u, pairs %2u (NS) + %2u (EW)\n"
 msgstr "ronde %u, tafel %u, paren %2u (NZ) + %2u (OW)\n"
 
-#: ..\src\debug.cpp:1333
+#: ..\src\debug.cpp:1327
 #, c-format
 msgid "Table %u:\n"
 msgstr "Tafel %u:\n"
 
-#: ..\src\debug.cpp:1339
+#: ..\src\debug.cpp:1333
 #, c-format
 msgid "round %u, games %s, pairs %2u (NS) + %2u (EW)  %s\n"
 msgstr "ronde %u, spellen %s, paren %2u (NZ) + %2u (OW)  %s\n"
 
-#: ..\src\debug.cpp:1393
+#: ..\src\debug.cpp:1387
 #, c-format
 msgid "Current group is within match-schema, take group > %u\n"
 msgstr "Huidige groep zit in wedstrijd schema, neem groep > %u\n"
 
-#: ..\src\debug.cpp:1401
+#: ..\src\debug.cpp:1395
 msgid " init of guidedata failed\n"
 msgstr " initgidsdata mislukt\n"
 
-#: ..\src\debug.cpp:1405
+#: ..\src\debug.cpp:1399
 msgid "choose a schema"
 msgstr "kies een schema"
 
-#: ..\src\debug.cpp:1429
+#: ..\src\debug.cpp:1423
 msgid "off"
 msgstr "uit"
 
-#: ..\src\debug.cpp:1429
+#: ..\src\debug.cpp:1423
 msgid "on"
 msgstr "aan"
 
-#: ..\src\debug.cpp:1429
+#: ..\src\debug.cpp:1423
 #, c-format
 msgid "testing is now %s for TestRSP()\n"
 msgstr "testen staat nu %s voor TestRSP()\n"
 
-#: ..\src\debug.cpp:1450
-msgid " doubled"
-msgstr " gedubbeld"
-
-#: ..\src\debug.cpp:1450
-msgid " re-doubled"
-msgstr " geredubbeld"
-
-#: ..\src\debug.cpp:1451
-msgid "clubs/diamonts"
-msgstr "klaveren/ruiten"
-
-#: ..\src\debug.cpp:1451
-msgid "hearts/spades"
-msgstr "harten/schoppen"
-
-#: ..\src\debug.cpp:1451
-msgid "no trump"
-msgstr "sans atout"
-
-#: ..\src\debug.cpp:1522
-msgid "more down then contract-tricks??\n"
-msgstr "meer down dan te behalen aantal slagen??\n"
-
-#: ..\src\debug.cpp:1526
+#: ..\src\debug.cpp:1450 ..\src\debug.cpp:2318
 #, c-format
-msgid "%d down %s, "
-msgstr "%d down %s, "
+msgid ", score vulnerable: %i, not vulnerable: %i\n"
+msgstr ", score kwetsbaar: %i, niet kwetsbaar: %i\n"
 
-#: ..\src\debug.cpp:1552
-msgid "more tricks then possible in a game??\n"
-msgstr "meer slagen dan er in een spel zijn??\n"
-
-#: ..\src\debug.cpp:1620
-#, c-format
-msgid "score vulnerable: %d, not vulnerable: %d\n"
-msgstr "score kwetsbaar: %d, niet kwetsbaar: %d\n"
-
-#: ..\src\debug.cpp:1627
+#: ..\src\debug.cpp:1463
 msgid ""
 "^-- unknown command\n"
 "   [l]Rx[@]PySzTq = list [Round x] [Pair y] [Game z] [Table q]\n"
@@ -1157,9 +1124,12 @@ msgid ""
 "   gx        = go to group x\n"
 "   n         = yes<->no testing of setentry\n"
 "   d         = debug: test schema's\n"
-"   x k|r|h|s|z [*[*]] [[+|-]y]: calculate score for 'x' clubs/diamonds/hearts/spades/no-trump\n"
-"               with 'y' up/down-tricks [[re]doubled]\n"
 "   o         = overview active schema\n"
+"   -x[*[*]] or y'SUIT'[[+|-]x][*[*]]   calculate the score for:\n"
+"             'x'    = the number of over/under tricks.\n"
+"             'y'    = the level of the contract.\n"
+"             'SUIT' = the type of the contract (or, when abbreviated, the first match in the card-names)\n"
+"             '*'    = doubled, and '**' is redoubled\n"
 msgstr ""
 "^-- onbekend kommando\n"
 "   [l]Rx[@]PySzTq = list [Ronde x] [Paar y] [Spel z] [Tafel q]\n"
@@ -1167,65 +1137,72 @@ msgstr ""
 "   gx        = ga naar groep x\n"
 "   n         = wel<->niet testen van setingave\n"
 "   d         = debug: test schema's\n"
-"   x k|r|h|s|z [*[*]] [[+|-]y]: bereken score voor 'x' kl/ru/ha/sc/sa\n"
-"               met 'y' over/down-slagen [ge[re]dubbeld]\n"
 "   o         = overzicht aktief schema\n"
+"   -x[*[*]] of y'KLEUR'[[+|-]x][*[*]]    bereken score voor:\n"
+"             'x'     = het aantal over/down-slagen.\n"
+"             'y'     = de hoogte van het contract.\n"
+"             'KLEUR' = het type contract (of, bij afkorting, de eerste overeenkomst in de kaart-namen)\n"
+"             '*'     = gedubbeld en '**' is geredubbeld\n"
 
-#: ..\src\debug.cpp:1653
+#: ..\src\debug.cpp:1476
+msgid "SUIT"
+msgstr "KLEUR"
+
+#: ..\src\debug.cpp:1499
 msgid "this group is not initialized (yet), defaults:\n"
 msgstr "deze groep is (nog) niet geinitialiseerd, defaults:\n"
 
-#: ..\src\debug.cpp:1662
+#: ..\src\debug.cpp:1508
 #, c-format
 msgid "rounds %u, pairs %u, tables %u (%s)\n"
 msgstr "rondes %u, paren %u, tafels %u (%s)\n"
 
-#: ..\src\debug.cpp:1808
+#: ..\src\debug.cpp:1654
 #, c-format
 msgid "schema for %2u tables, %2u rounds, %2u pairs (%s)\n"
 msgstr "schema voor %2u tafels, %2u rondes, %2u paren (%s)\n"
 
-#: ..\src\debug.cpp:1820
+#: ..\src\debug.cpp:1666
 #, c-format
 msgid "pair %u has no opponent in round %u\n"
 msgstr "paar %u heeft geen tegenpaar in ronde %u\n"
 
-#: ..\src\debug.cpp:1825
+#: ..\src\debug.cpp:1671
 #, c-format
 msgid "pair %u has too high opponent %u in round %u\n"
 msgstr "paar %u heeft te groot tegenpaar %u in ronde %u\n"
 
-#: ..\src\debug.cpp:1830
+#: ..\src\debug.cpp:1676
 #, c-format
 msgid "pair %u plays %u times against pair %u\n"
 msgstr "paar %u speelt %u keer tegen paar %u\n"
 
-#: ..\src\debug.cpp:1834
+#: ..\src\debug.cpp:1680
 #, c-format
 msgid "pair %u has a too large gameset %u in round %u\n"
 msgstr "paar %u heeft te grote spelset %u in ronde %u\n"
 
-#: ..\src\debug.cpp:1839
+#: ..\src\debug.cpp:1685
 #, c-format
 msgid "pair %u has unknown gameset %u in round %u\n"
 msgstr "paar %u heeft onbekende spelset %u in ronde %u\n"
 
-#: ..\src\debug.cpp:1844
+#: ..\src\debug.cpp:1690
 #, c-format
 msgid "pair %u playes %u times set %u\n"
 msgstr "paar %u speelt %u keer set %u\n"
 
-#: ..\src\debug.cpp:1847
+#: ..\src\debug.cpp:1693
 #, c-format
 msgid "pair %u playes only %u times\n"
 msgstr "paar %u speelt maar %u keer\n"
 
-#: ..\src\debug.cpp:1864
+#: ..\src\debug.cpp:1710
 #, c-format
 msgid "in round %u, table %u pair %u and %u are playing in the same direction (%s)\n"
 msgstr "in ronde %u, tafel %u spelen paar %u en %u in dezelfde richting (%s)\n"
 
-#: ..\src\debug.cpp:1879
+#: ..\src\debug.cpp:1725
 #, c-format
 msgid ""
 "Set-size(%u) too large,\n"
@@ -1234,95 +1211,128 @@ msgstr ""
 "Set-grootte(%u) is te hoog,\n"
 "maximum is 6"
 
-#: ..\src\debug.cpp:1951
+#: ..\src\debug.cpp:1797
 msgid "ROUND :"
 msgstr "RONDE :"
 
-#: ..\src\debug.cpp:1952
+#: ..\src\debug.cpp:1798
 msgid "TABLE :"
 msgstr "TAFEL :"
 
-#: ..\src\debug.cpp:1953
+#: ..\src\debug.cpp:1799
 msgid "   NS :"
 msgstr "   NZ :"
 
-#: ..\src\debug.cpp:1954
+#: ..\src\debug.cpp:1800
 msgid "   EW :"
 msgstr "   OW :"
 
-#: ..\src\debug.cpp:1955
+#: ..\src\debug.cpp:1801
 msgid "ini.NS"
 msgstr "par.NZ"
 
-#: ..\src\debug.cpp:1956
+#: ..\src\debug.cpp:1802
 msgid "ini.EW"
 msgstr "par.OW"
 
-#: ..\src\debug.cpp:1957
+#: ..\src\debug.cpp:1803
 msgid "Game"
 msgstr "Spel"
 
-#: ..\src\debug.cpp:1958
+#: ..\src\debug.cpp:1804
 msgid "Contract"
-msgstr "Kontrakt"
+msgstr "Contract"
 
-#: ..\src\debug.cpp:1959
+#: ..\src\debug.cpp:1805
 msgid "NS       EW"
 msgstr "NZ       OW"
 
 #. TRANSLATORS: text centered in 9 characters
-#: ..\src\debug.cpp:1961
+#: ..\src\debug.cpp:1807
 msgid " Result  "
 msgstr "Resultaat"
 
-#: ..\src\debug.cpp:1962
+#: ..\src\debug.cpp:1808
 msgid "NS score + or -"
 msgstr "NZ score + of -"
 
-#: ..\src\debug.cpp:2087
+#: ..\src\debug.cpp:1933
 msgid "round"
 msgstr "ronde"
 
-#: ..\src\debug.cpp:2088
+#: ..\src\debug.cpp:1934
 msgid "table"
 msgstr "tafel"
 
 # no error
-#: ..\src\debug.cpp:2089
+#: ..\src\debug.cpp:1935
 msgid "opp."
 msgstr "tegen"
 
-#: ..\src\debug.cpp:2092
+#: ..\src\debug.cpp:1938
 #, c-format
 msgid "schema: %22s"
 msgstr "schema: %22s"
 
-#: ..\src\debug.cpp:2118
+#: ..\src\debug.cpp:1964
 #, c-format
 msgid "Pair %2s%-2u             %2u pairs"
 msgstr "Paar %2s%-2u             %2u paren"
 
-#: ..\src\debug.cpp:2221
+#: ..\src\debug.cpp:2067
 msgid "round ->"
 msgstr "ronde ->"
 
-#: ..\src\debug.cpp:2223
+#: ..\src\debug.cpp:2069
 msgid "tbl"
 msgstr "tfl"
 
-#: ..\src\debug.cpp:2224
+#: ..\src\debug.cpp:2070
 #, c-format
 msgid "%u pairs, %u rounds, %u games"
 msgstr "%u paren, %u rondes, %u spellen"
 
-#: ..\src\debug.cpp:2225
+#: ..\src\debug.cpp:2071
 #, c-format
 msgid "Schema: %s"
 msgstr "Schema: %s"
 
-#: ..\src\debug.cpp:2279
+#: ..\src\debug.cpp:2125
 msgid "Schemaoverview"
 msgstr "Schemaoverzicht"
+
+#: ..\src\debug.cpp:2146 ..\src\score.cpp:398
+msgid "doubled"
+msgstr "gedubbeld"
+
+#: ..\src\debug.cpp:2146 ..\src\score.cpp:398
+msgid "redoubled"
+msgstr "geredubbeld"
+
+#: ..\src\debug.cpp:2147 ..\src\score.cpp:397
+msgid "Clubs/Diamonds"
+msgstr "Klaveren/Ruiten"
+
+#: ..\src\debug.cpp:2147 ..\src\score.cpp:397
+msgid "Hearts/Spades"
+msgstr "Harten/Schoppen"
+
+#: ..\src\debug.cpp:2147 ..\src\score.cpp:394 ..\src\score.cpp:397
+msgid "NoTrump"
+msgstr "SansAtout"
+
+#: ..\src\debug.cpp:2218 ..\src\score.cpp:460 ..\src\score.cpp:473
+msgid "more down then contract-tricks??\n"
+msgstr "meer down dan te behalen aantal slagen??\n"
+
+#: ..\src\debug.cpp:2222 ..\src\score.cpp:587
+#, c-format
+msgid "%i down %s"
+msgstr "%i down %s"
+
+#: ..\src\debug.cpp:2249 ..\src\score.cpp:468 ..\src\score.cpp:488
+msgid "more tricks then possible in a game??\n"
+msgstr "meer slagen dan er in een spel zijn??\n"
 
 #: ..\src\fileIo.cpp:21
 msgid ""
@@ -1379,272 +1389,272 @@ msgstr "Systeemtaal: id=%d, %s"
 msgid "Systemlanguage: the default system language"
 msgstr "Systeemtaal: de default systeem taal"
 
-#: ..\src\main.cpp:475
+#: ..\src\main.cpp:476
 msgid "MyApp::OnInit() finished, showing startup picture"
 msgstr "MyApp::OnInit() finished, showing startup picture"
 
-#: ..\src\main.cpp:480
+#: ..\src\main.cpp:481
 msgid "'Bridge' scoring program"
 msgstr "Bridge rekenprogramma"
 
-#: ..\src\main.cpp:549
+#: ..\src\main.cpp:550
 #, c-format
 msgid "Mainwindow position: {%i,%i}, size: %i*%i"
 msgstr "Mainwindow position: {%i,%i}, size: %i*%i"
 
-#: ..\src\main.cpp:564
+#: ..\src\main.cpp:565
 msgid "&New match/session"
 msgstr "&Nieuwe wedstrijd/zitting"
 
-#: ..\src\main.cpp:564
+#: ..\src\main.cpp:565
 msgid "Match/session entry"
 msgstr "Wedstrijd/zitting ingave"
 
-#: ..\src\main.cpp:565
+#: ..\src\main.cpp:566
 msgid "&Printer choice"
 msgstr "&Printerkeuze"
 
-#: ..\src\main.cpp:565
+#: ..\src\main.cpp:566
 msgid "Printer choice and setup"
 msgstr "Printer keuze en instellingen"
 
-#: ..\src\main.cpp:566
+#: ..\src\main.cpp:567
 msgid "Print current page"
 msgstr "Print huidige pagina"
 
-#: ..\src\main.cpp:566
+#: ..\src\main.cpp:567
 msgid "print pa&Ge"
 msgstr "print pa&Gina"
 
-#: ..\src\main.cpp:567
+#: ..\src\main.cpp:568
 msgid "Print a file"
 msgstr "Print een bestand"
 
-#: ..\src\main.cpp:567
+#: ..\src\main.cpp:568
 msgid "print &File"
 msgstr "print &Bestand"
 
-#: ..\src\main.cpp:570
+#: ..\src\main.cpp:571
 msgid "&Exit"
 msgstr "&Afsluiten"
 
-#: ..\src\main.cpp:570
+#: ..\src\main.cpp:571
 msgid "This will end the program"
 msgstr "Dit zal het programma beeindigen"
 
-#: ..\src\main.cpp:573
+#: ..\src\main.cpp:574
 msgid "&Match"
 msgstr "&Wedstrijd"
 
-#: ..\src\main.cpp:573
+#: ..\src\main.cpp:574
 msgid "Setup for the active match"
 msgstr "Instellingen tbv de aktieve wedstrijd"
 
-#: ..\src\main.cpp:574
+#: ..\src\main.cpp:575
 msgid "&Schema"
 msgstr "Schema"
 
-#: ..\src\main.cpp:574
+#: ..\src\main.cpp:575
 msgid "Entry/change of schema"
 msgstr "Ingave/wijzigen van schema"
 
-#: ..\src\main.cpp:575 ..\src\nameEditor.cpp:51
+#: ..\src\main.cpp:576 ..\src\nameEditor.cpp:51
 msgid "Entry/change of pair/clubnames"
 msgstr "Ingave/wijzigen van paar/club namen"
 
-#: ..\src\main.cpp:575
+#: ..\src\main.cpp:576
 msgid "pairnames &Entry/change"
 msgstr "paarnamen &Ingeven/wijzigen"
 
-#: ..\src\main.cpp:576
+#: ..\src\main.cpp:577
 msgid "Connect a global pairname to a sessionpairnumber"
 msgstr "Paarnaam koppelen aan paarnummer van zitting"
 
-#: ..\src\main.cpp:576
+#: ..\src\main.cpp:577
 msgid "pairnames &Assigment"
 msgstr "paarnamen &Toekennen"
 
-#: ..\src\main.cpp:580
+#: ..\src\main.cpp:581
 msgid "Entry/change of scores"
 msgstr "Ingeven/aanpassen scores"
 
-#: ..\src\main.cpp:580
+#: ..\src\main.cpp:581
 msgid "s&Core-entry"
 msgstr "&Score ingave"
 
-#: ..\src\main.cpp:581
+#: ..\src\main.cpp:582
 msgid "&Sessioncorrections"
 msgstr "&Zitting correcties"
 
-#: ..\src\main.cpp:581
+#: ..\src\main.cpp:582
 msgid "Entry/change of session corrections"
 msgstr "Ingeven/aanpassen correcties tbv een zitting"
 
-#: ..\src\main.cpp:582
+#: ..\src\main.cpp:583
 msgid "&Endcorrections"
 msgstr "&Eind correcties"
 
-#: ..\src\main.cpp:582
+#: ..\src\main.cpp:583
 msgid "Entry/change of end corrections"
 msgstr "Ingeven/aanpassen correcties voor de einduitslag"
 
-#: ..\src\main.cpp:583
+#: ..\src\main.cpp:584
 msgid "&Results"
 msgstr "&Uitslag"
 
-#: ..\src\main.cpp:583
+#: ..\src\main.cpp:584
 msgid "Calculation of session/end result"
 msgstr "Berekenen van de zitting/eind uitslag"
 
-#: ..\src\main.cpp:586
+#: ..\src\main.cpp:587
 msgid "&Log window"
 msgstr "&Log window"
 
-#: ..\src\main.cpp:586
+#: ..\src\main.cpp:587
 msgid "Enable/disable logging window"
 msgstr "Aan / uitzetten van log window"
 
-#: ..\src\main.cpp:587
+#: ..\src\main.cpp:588
 msgid "&Debug window"
 msgstr "&Debug window"
 
-#: ..\src\main.cpp:587
+#: ..\src\main.cpp:588
 msgid "Debug window for all kind of stuff"
 msgstr "Debug window voor allerlei zaken"
 
-#: ..\src\main.cpp:588
+#: ..\src\main.cpp:589
 msgid "&Guides"
 msgstr "&Gidsbriefjes"
 
-#: ..\src\main.cpp:588
+#: ..\src\main.cpp:589
 msgid "Creation of guides"
 msgstr "Aanmaak van gidsbriefjes"
 
-#: ..\src\main.cpp:589
+#: ..\src\main.cpp:590
 msgid "&Scoreslips"
 msgstr "&Scoreslips"
 
-#: ..\src\main.cpp:589
+#: ..\src\main.cpp:590
 msgid "Creation of scoreslips"
 msgstr "Aanmaak van scoreslips"
 
-#: ..\src\main.cpp:590
+#: ..\src\main.cpp:591
 msgid "&Import schema"
 msgstr "&Importeer schema"
 
-#: ..\src\main.cpp:590
+#: ..\src\main.cpp:591
 msgid "Import a new schema (.asc) for playing"
 msgstr "Importeer een nieuw (.asc) speelschema"
 
-#: ..\src\main.cpp:592
+#: ..\src\main.cpp:593
 msgid "&Old -> database"
 msgstr "&Oud -> database"
 
-#: ..\src\main.cpp:592
+#: ..\src\main.cpp:593
 msgid "Convert 'old' .ini/data files to single new .db file"
 msgstr "Omzetten van 'oude' .ini/data bestanden naar een enkel .db bestand"
 
-#: ..\src\main.cpp:593
+#: ..\src\main.cpp:594
 msgid "&Database -> old"
 msgstr "&Database -> oud"
 
-#: ..\src\main.cpp:593
+#: ..\src\main.cpp:594
 msgid "Convert .db file to 'old' .ini/data files"
 msgstr "Omzetten van .db bestand naar 'oude' .ini/data bestanden"
 
-#: ..\src\main.cpp:594
+#: ..\src\main.cpp:595
 msgid "&Convert data"
 msgstr "&Converteren data"
 
-#: ..\src\main.cpp:594
+#: ..\src\main.cpp:595
 msgid "convert match-data between old/new types"
 msgstr "wedstrijdgegevens omzetten van het ene type naar het andere"
 
-#: ..\src\main.cpp:596
+#: ..\src\main.cpp:597
 msgid "&Old datatype (.ini)"
 msgstr "&Oud bestandstype (.ini)"
 
-#: ..\src\main.cpp:596
+#: ..\src\main.cpp:597
 msgid "Use 'old' .ini/data files for data storage"
 msgstr "Gebruik van 'oude' .ini/data bestanden voor opslag"
 
-#: ..\src\main.cpp:597
+#: ..\src\main.cpp:598
 msgid "&New datatype (.db)"
 msgstr "&Nieuw bestandstype (.db)"
 
-#: ..\src\main.cpp:597
+#: ..\src\main.cpp:598
 msgid "Use new .db file for data storage"
 msgstr "Gebruik van nieuw .db bestand voor opslag"
 
-#: ..\src\main.cpp:598
+#: ..\src\main.cpp:599
 msgid "s&Witch between datatypes"
 msgstr "&Wissel van bestandstype"
 
-#: ..\src\main.cpp:598
+#: ..\src\main.cpp:599
 msgid "switch between the two datatypes"
 msgstr "omschakelen van het ene opslagtype naar het andere"
 
-#: ..\src\main.cpp:599
+#: ..\src\main.cpp:600
 msgid "&Language"
 msgstr "&Taal"
 
-#: ..\src\main.cpp:599
+#: ..\src\main.cpp:600
 msgid "language of the userinterface"
 msgstr "taal van de gebruikers interface"
 
-#: ..\src\main.cpp:602
+#: ..\src\main.cpp:603
 msgid "&System info"
 msgstr "&Systeem info"
 
-#: ..\src\main.cpp:602
+#: ..\src\main.cpp:603
 msgid "Info about the version of wxWidgets"
 msgstr "Info over versie van wxWidgets"
 
-#: ..\src\main.cpp:603
+#: ..\src\main.cpp:604
 msgid "&About "
 msgstr "&Over "
 
-#: ..\src\main.cpp:606 ..\src\mylog.cpp:114
+#: ..\src\main.cpp:607 ..\src\mylog.cpp:114
 msgid "&File"
 msgstr "&Bestand"
 
-#: ..\src\main.cpp:607
+#: ..\src\main.cpp:608
 msgid "&Settings"
 msgstr "&Instellingen"
 
-#: ..\src\main.cpp:608
+#: ..\src\main.cpp:609
 msgid "s&Cores"
 msgstr "&Scores"
 
-#: ..\src\main.cpp:609
+#: ..\src\main.cpp:610
 msgid "&Tools"
 msgstr "&Extra"
 
-#: ..\src\main.cpp:610
+#: ..\src\main.cpp:611
 msgid "&Help"
 msgstr "&Help"
 
-#: ..\src\main.cpp:619
+#: ..\src\main.cpp:620
 msgid "Welcome at "
 msgstr "Welkom bij "
 
-#: ..\src\main.cpp:641
+#: ..\src\main.cpp:642
 msgid "hello in the console!"
 msgstr "hallo in de console!"
 
-#: ..\src\main.cpp:644
+#: ..\src\main.cpp:645
 msgid "Debug active"
 msgstr "Debug active"
 
-#: ..\src\main.cpp:660
+#: ..\src\main.cpp:661
 msgid "PrintPage()"
 msgstr "PrintPage()"
 
-#: ..\src\main.cpp:670
+#: ..\src\main.cpp:671
 msgid ", from "
 msgstr ", uit "
 
-#: ..\src\main.cpp:671
+#: ..\src\main.cpp:672
 #, c-format
 msgid ""
 "\n"
@@ -1665,152 +1675,152 @@ msgstr ""
 "\n"
 "(c) wxSystemInformationFrame, PB: https://github.com/PBfordev"
 
-#: ..\src\main.cpp:678
+#: ..\src\main.cpp:679
 msgid "About "
 msgstr "Over "
 
-#: ..\src\main.cpp:722
+#: ..\src\main.cpp:723
 msgid "MenuNewMatch      := \"fn\"       ; File: New match/session"
 msgstr "MenuNewMatch      := \"bn\"       ; Bestand: Nieuw"
 
-#: ..\src\main.cpp:723
+#: ..\src\main.cpp:724
 msgid "MenuShutdown      := \"fe\"       ; File: Exit"
 msgstr "MenuShutdown      := \"ba\"       ; Bestand: Afsluiten"
 
-#: ..\src\main.cpp:724
+#: ..\src\main.cpp:725
 msgid "MenuPrinter       := \"fp\"       ; File: Printer choice"
 msgstr "MenuPrinter       := \"bp\"       ; Bestand: Printer"
 
-#: ..\src\main.cpp:725
+#: ..\src\main.cpp:726
 msgid "MenuPrintPage     := \"fg\"       ; File: print paGe"
 msgstr "MenuPrintPage     := \"bg\"       ; Bestand: printpaGina"
 
-#: ..\src\main.cpp:726
+#: ..\src\main.cpp:727
 msgid "MenuSetupMatch    := \"sm\"       ; Settings: setup Match"
 msgstr "MenuSetupMatch    := \"iw\"       ; Instellingen: Wedstrijd"
 
-#: ..\src\main.cpp:727
+#: ..\src\main.cpp:728
 msgid "MenuSetupSchema   := \"ss\"       ; Settings: setup Schema"
 msgstr "MenuSetupSchema   := \"is\"       ; Instellingen: Schema"
 
-#: ..\src\main.cpp:728
+#: ..\src\main.cpp:729
 msgid "MenuNamesInit     := \"se\"       ; Settings: pairnames Entry/change"
 msgstr "MenuNamesInit     := \"ii\"       ; Instellingen: Ingeven"
 
-#: ..\src\main.cpp:729
+#: ..\src\main.cpp:730
 msgid "MenuNamesAssign   := \"sa\"       ; Settings: pairnames Assignment"
 msgstr "MenuNamesAssign   := \"it\"       ; Instellingen: Toekennen"
 
-#: ..\src\main.cpp:730
+#: ..\src\main.cpp:731
 msgid "MenuScoreEntry    := \"cc\"       ; sCores: sCoreentry"
 msgstr "MenuScoreEntry    := \"ss\"       ; Scores: Scores"
 
-#: ..\src\main.cpp:731
+#: ..\src\main.cpp:732
 msgid "MenuCorSession    := \"cs\"       ; sCores: entry Sesssioncorrections"
 msgstr "MenuCorSession    := \"sz\"       ; Scores: Zittingcorrecties"
 
-#: ..\src\main.cpp:732
+#: ..\src\main.cpp:733
 msgid "MenuCorEnd        := \"ce\"       ; sCores: entry Endcorrections"
 msgstr "MenuCorEnd        := \"se\"       ; Scores: Eindcorrecties"
 
-#: ..\src\main.cpp:733
+#: ..\src\main.cpp:734
 msgid "MenuResult        := \"cr\"       ; sCores: calculate Results"
 msgstr "MenuResult        := \"su\"       ; Scores: Uitslag"
 
-#: ..\src\main.cpp:734
+#: ..\src\main.cpp:735
 msgid "MenuDebug         := \"td\"       ; Tools: Debug window"
 msgstr "MenuDebug         := \"ed\"       ; Extra: Debug window"
 
-#: ..\src\main.cpp:735
+#: ..\src\main.cpp:736
 msgid "MenuGuides        := \"tg\"       ; Tools: Guide creation"
 msgstr "MenuGuides        := \"eg\"       ; Extra: Gidsbriefjes"
 
-#: ..\src\main.cpp:736
+#: ..\src\main.cpp:737
 msgid "MenuScoreSlips    := \"ts\"       ; Tools: Scoreslip creation"
 msgstr "MenuScoreSlips    := \"es\"       ; Extra: Scoreslips aanmaken"
 
-#: ..\src\main.cpp:737
+#: ..\src\main.cpp:738
 msgid "MenuImportSchema  := \"ti\"       ; Tools: Import a new playing-schema"
 msgstr "MenuImportSchema  := \"ei\"       ; Extra: Importeren van een nieuw speelschema"
 
-#: ..\src\main.cpp:738
+#: ..\src\main.cpp:739
 msgid "MenuDbType        := \"twn\"      ; Tools: sWitch between datatypes: New datatype"
 msgstr "MenuDbType        := \"ewn\"      ; Extra: Wissel Nieuw"
 
-#: ..\src\main.cpp:739
+#: ..\src\main.cpp:740
 msgid "MenuOldType       := \"two\"      ; Tools: sWitch between datatypes: Old datatype"
 msgstr "MenuOldType       := \"ewo\"      ; Extra: Wissel Oud"
 
-#: ..\src\main.cpp:740
+#: ..\src\main.cpp:741
 msgid "AllMenus          := [\"fn\",\"fp\",\"fg\",\"sm\",\"ss\",\"se\",\"sa\",\"cc\",\"cs\",\"ce\",\"cr\",\"two\",\"twn\"]"
 msgstr "AllMenus          := [\"bn\",\"bp\",\"bg\",\"iw\",\"is\",\"ii\",\"it\",\"ss\",\"sz\",\"se\",\"su\",\"ewo\",\"ewn\"]"
 
-#: ..\src\main.cpp:744
+#: ..\src\main.cpp:745
 msgid "changed"
 msgstr "gewijzigd"
 
-#: ..\src\main.cpp:785
+#: ..\src\main.cpp:786
 #, c-format
 msgid "Menu backup current(%u: %s)"
 msgstr "Menu backup current(%u: %s)"
 
-#: ..\src\main.cpp:796
+#: ..\src\main.cpp:797
 #, c-format
 msgid "Menu old page(%u: %s)"
 msgstr "Menu old page(%u: %s)"
 
-#: ..\src\main.cpp:804
+#: ..\src\main.cpp:805
 #, c-format
 msgid "Menu old show(%u)"
 msgstr "Menu old show(%u)"
 
-#: ..\src\main.cpp:810
+#: ..\src\main.cpp:811
 #, c-format
 msgid "Menu new page(%u)"
 msgstr "Menu new page(%u)"
 
-#: ..\src\main.cpp:853
+#: ..\src\main.cpp:854
 #, c-format
 msgid "OnMenu(%u), id unknown!"
 msgstr "OnMenu(%u), id unknown!"
 
-#: ..\src\main.cpp:857
+#: ..\src\main.cpp:858
 #, c-format
 msgid "Menu new show(%u: %s)"
 msgstr "Menu new show(%u: %s)"
 
-#: ..\src\main.cpp:886
+#: ..\src\main.cpp:887
 msgid "Choose a language (and restart)"
 msgstr "Kies een taal (en start opnieuw op)"
 
-#: ..\src\main.cpp:886
+#: ..\src\main.cpp:887
 msgid "Language selection"
 msgstr "Taalselectie"
 
-#: ..\src\main.cpp:896
+#: ..\src\main.cpp:897
 #, c-format
 msgid "Languagechoice: id=%d, name=%s"
 msgstr "Taalkeuze: id=%d, naam=%s"
 
-#: ..\src\main.cpp:903
+#: ..\src\main.cpp:904
 msgid "Choose a file for printing"
 msgstr "Kies een bestand om te printen"
 
-#: ..\src\main.cpp:907
+#: ..\src\main.cpp:908
 #, c-format
 msgid "Printing file <%s>"
 msgstr "Afdrukken van bestand <%s>"
 
-#: ..\src\main.cpp:917
+#: ..\src\main.cpp:918
 msgid "Choose a schema file to import"
 msgstr "Kies een schemabestand om te importeren"
 
-#: ..\src\main.cpp:926
+#: ..\src\main.cpp:927
 #, c-format
 msgid "Importing file <%s>"
 msgstr "Bestand importeren <%s>"
 
-#: ..\src\main.cpp:930
+#: ..\src\main.cpp:931
 msgid "Don't import a schema from the basefolder itself!"
 msgstr "Je kunt geen schema importeren uit de basefolder zelf!"
 
@@ -2025,112 +2035,148 @@ msgstr "              blz %d: "
 msgid "NP"
 msgstr "NG"
 
-#: ..\src\scoreEntry.cpp:44
+#: ..\src\score.cpp:390
+msgid "Clubs"
+msgstr "Klaveren"
+
+#: ..\src\score.cpp:391
+msgid "Diamonds"
+msgstr "Ruiten"
+
+#: ..\src\score.cpp:392
+msgid "Hearts"
+msgstr "Harten"
+
+#: ..\src\score.cpp:393
+msgid "Spades"
+msgstr "Schoppen"
+
+#: ..\src\scoreEntry.cpp:45
 msgid "game"
 msgstr "spel"
 
-#: ..\src\scoreEntry.cpp:45
+#: ..\src\scoreEntry.cpp:46
 msgid "ns"
 msgstr "nz"
 
-#: ..\src\scoreEntry.cpp:46
+#: ..\src\scoreEntry.cpp:47
 msgid "ew"
 msgstr "ow"
 
-#: ..\src\scoreEntry.cpp:47
+#: ..\src\scoreEntry.cpp:48
 msgid "score ns"
 msgstr "score nz"
 
-#: ..\src\scoreEntry.cpp:48
+#: ..\src\scoreEntry.cpp:49
 msgid "score ew"
 msgstr "score ow"
 
-#: ..\src\scoreEntry.cpp:49
+#: ..\src\scoreEntry.cpp:50
 msgid "name ns"
 msgstr "naam nz"
 
-#: ..\src\scoreEntry.cpp:50
+#: ..\src\scoreEntry.cpp:51
 msgid "name ew"
 msgstr "naam ow"
 
-#: ..\src\scoreEntry.cpp:74
+#: ..\src\scoreEntry.cpp:52
+msgid "contract ns"
+msgstr "contract nz"
+
+#: ..\src\scoreEntry.cpp:53
+msgid "contract ew"
+msgstr "contract ow"
+
+#: ..\src\scoreEntry.cpp:77
 msgid "Score slip"
 msgstr "Score slip"
 
-#: ..\src\scoreEntry.cpp:75
+#: ..\src\scoreEntry.cpp:78
 msgid "Game number "
 msgstr "Spel nummer "
 
-#: ..\src\scoreEntry.cpp:76
+#: ..\src\scoreEntry.cpp:79
 msgid "Entry order:"
 msgstr "Ingave volgorde:"
 
-#: ..\src\scoreEntry.cpp:79
+#: ..\src\scoreEntry.cpp:82
 msgid "Game number"
 msgstr "Spel nummer"
 
-#: ..\src\scoreEntry.cpp:80
+#: ..\src\scoreEntry.cpp:83
 msgid "NS number"
 msgstr "NZ nummer"
 
-#: ..\src\scoreEntry.cpp:81
+#: ..\src\scoreEntry.cpp:84
 msgid "Score slip order:"
 msgstr "Score slip volgorde:"
 
-#: ..\src\scoreEntry.cpp:84
+#: ..\src\scoreEntry.cpp:87
 msgid "Round:"
 msgstr "Ronde:"
 
-#: ..\src\scoreEntry.cpp:84
+#: ..\src\scoreEntry.cpp:87
 msgid "Scores for this round"
 msgstr "Scores voor deze ronde"
 
-#: ..\src\scoreEntry.cpp:88
+#: ..\src\scoreEntry.cpp:91
 msgid "Scores for this game"
 msgstr "Scores voor dit spel"
 
-#: ..\src\scoreEntry.cpp:95
+#: ..\src\scoreEntry.cpp:98
 msgid "++empty score"
 msgstr "++lege score"
 
-#: ..\src\scoreEntry.cpp:97
+#: ..\src\scoreEntry.cpp:100
 msgid "jumps to next empty score"
 msgstr "gaat naar volgende lege score"
 
-#: ..\src\scoreEntry.cpp:99
+#: ..\src\scoreEntry.cpp:102
 msgid "ns<-->ew"
 msgstr "nz<-->ow"
 
-#: ..\src\scoreEntry.cpp:101
+#: ..\src\scoreEntry.cpp:104
 msgid "switch NS pair with EW pair: wrong direction"
 msgstr "wissel NZ paar met OW paar: draaitafel"
 
-#: ..\src\scoreEntry.cpp:116
+#: ..\src\scoreEntry.cpp:106
+msgid "contract entry"
+msgstr "contract invoer"
+
+#: ..\src\scoreEntry.cpp:108
+msgid "Enter contracts like: -x[*[*]] or y'SUIT'[[+|-]x][*[*]]"
+msgstr "Geef contracten in zoals: -x[*[*]] of y'KLEUR'[[+|-]x][*[*]]"
+
+#: ..\src\scoreEntry.cpp:125
 msgid "Entry/Change scores"
 msgstr "Ingave/Wijzigen scores"
 
-#: ..\src\scoreEntry.cpp:163
+#: ..\src\scoreEntry.cpp:197
+msgid "Can't interpret contract!"
+msgstr "Begrijp het contract niet!"
+
+#: ..\src\scoreEntry.cpp:220
 #, c-format
 msgid "ScoreEntry:: row %2d, column %d changing from <%s> to <%s>"
 msgstr "ScoreEntry:: rij %2d, colom %d verandert van <%s> naar <%s>"
 
-#: ..\src\scoreEntry.cpp:196
+#: ..\src\scoreEntry.cpp:248
 msgid "unexpected/special score, accept anyway?"
 msgstr "onverwachte/bijzondere score, toch accepteren?"
 
-#: ..\src\scoreEntry.cpp:197
+#: ..\src\scoreEntry.cpp:249
 msgid "invalid score, accept anyway?"
 msgstr "ongeldige score, toch accepteren?"
 
-#: ..\src\scoreEntry.cpp:487
+#: ..\src\scoreEntry.cpp:547
 msgid "Scoreentry: normal: <score>, adjusted: '%'<score> or 'r'<score> or 'np'=not played"
 msgstr "Ingave scores: normaal: <score>, arbitraal: '%'<score> of 'r'<score> of 'ng'=niet gespeeld"
 
-#: ..\src\scoreEntry.cpp:491 ..\src\setupSchema.cpp:267
+#: ..\src\scoreEntry.cpp:551 ..\src\setupSchema.cpp:267
 msgid "not all groups have a valid schema"
 msgstr "niet alle groepen hebben een geldig schema"
 
-#: ..\src\scoreEntry.cpp:552
+#: ..\src\scoreEntry.cpp:612
 #, c-format
 msgid ""
 "'%s-%s' exchange with '%s-%s', are you sure?\n"
@@ -2141,26 +2187,26 @@ msgstr ""
 "\n"
 " "
 
-#: ..\src\scoreEntry.cpp:553
+#: ..\src\scoreEntry.cpp:613
 msgid "wrong direction"
 msgstr "draaihand"
 
-#: ..\src\scoreEntry.cpp:608
+#: ..\src\scoreEntry.cpp:668
 #, c-format
 msgid " of session %u"
 msgstr " van zitting %u"
 
-#: ..\src\scoreEntry.cpp:609
+#: ..\src\scoreEntry.cpp:669
 #, c-format
 msgid "game %u"
 msgstr "spel %u"
 
-#: ..\src\scoreEntry.cpp:609
+#: ..\src\scoreEntry.cpp:669
 #, c-format
 msgid "round %u"
 msgstr "ronde %u"
 
-#: ..\src\scoreEntry.cpp:610
+#: ..\src\scoreEntry.cpp:670
 #, c-format
 msgid "Overview of the scores%s for '%s', %s"
 msgstr "Overzicht van de scores%s voor '%s', %s"
@@ -2576,88 +2622,5 @@ msgstr "1 januari 2024"
 msgid "monday"
 msgstr "maandag"
 
-#~ msgid "ERROR"
-#~ msgstr "ERROR"
-
-#, fuzzy
-#~| msgid "Warning"
-#~ msgid "warning"
-#~ msgstr "Waarschuwing"
-
-#~ msgid "Result"
-#~ msgstr "Resultaat"
-
-#, c-format
-#~ msgid "%3u  NOT PLAYED?? absent??"
-#~ msgstr "%3u  STIL-ZIT?? afwezig??"
-
-#, c-format
-#~ msgid "  %s   %savg. %s"
-#~ msgstr "  %s   %sgem. %s"
-
-#~ msgid "total "
-#~ msgstr "totaal "
-
-#, c-format
-#~ msgid ""
-#~ "Rounds       :%2s    Games: %s    First game: %s\n"
-#~ "Games/table  :%2s\n"
-#~ "Groups       :%2s\n"
-#~ "\n"
-#~ msgstr ""
-#~ "Rondes       :%2s    Spellen: %s    Eerste spel: %s\n"
-#~ "Spellen/tafel:%2s\n"
-#~ "Groepen      :%2s\n"
-#~ "\n"
-
-#~ msgid "group groupchars   pairs schema          absent pair\n"
-#~ msgstr "groep groepletters paren schema          afwezig paar\n"
-
-#, c-format
-#~ msgid ""
-#~ "Description     : %s\n"
-#~ "Max %s absent : %s\n"
-#~ "MinMax clubpairs: %s-%s\n"
-#~ "Neuberg         : %s\n"
-#~ "Weighted average: %s\n"
-#~ "Groupresult     : %s\n"
-#~ "Global names    : %s\n"
-#~ "Clock           : %s\n"
-#~ msgstr ""
-#~ "Beschrijving      : %s\n"
-#~ "Max %s afwezig  : %s\n"
-#~ "MinMax clubparen  : %s-%s\n"
-#~ "Neuberg           : %s\n"
-#~ "Gewogen gemiddelde: %s\n"
-#~ "Groepuitslag      : %s\n"
-#~ "Centrale namen    : %s\n"
-#~ "klok              : %s\n"
-
-#, c-format
-#~ msgid ""
-#~ "Printer         : %s\n"
-#~ "Lines/page      : %s\n"
-#~ "Formfeed        : %s\n"
-#~ "Networkprinter  : %s\n"
-#~ msgstr ""
-#~ "Printer         : %s\n"
-#~ "Regels/bladzijde: %s\n"
-#~ "Formfeed        : %s\n"
-#~ "Netwerkprinter  : %s\n"
-
-#, c-format
-#~ msgid ""
-#~ "Matchfolder  : %s\n"
-#~ "Match        : %s\n"
-#~ "Session      : %s\n"
-#~ "Databasetype : %s\n"
-#~ "Butler       : %s\n"
-#~ msgstr ""
-#~ "Wedstrijdmap: %s\n"
-#~ "Wedstrijd   : %s\n"
-#~ "Zitting     : %s\n"
-#~ "Opslagtype  : %s\n"
-#~ "Butler      : %s\n"
-
-#~ msgid "WARNING"
-#~ msgstr "WAARSCHUWING"
+#~ msgid "Malformed contract\n"
+#~ msgstr "Contract heeft fout formaat\n"

--- a/locales/nl.po
+++ b/locales/nl.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: BridgeWx\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-18 12:21+0100\n"
-"PO-Revision-Date: 2025-03-18 12:23+0100\n"
+"POT-Creation-Date: 2025-03-27 18:42+0100\n"
+"PO-Revision-Date: 2025-03-27 18:43+0100\n"
 "Last-Translator: BusyHarry\n"
 "Language-Team: \n"
 "Language: nl\n"
@@ -216,7 +216,7 @@ msgid "Session result on name"
 msgstr "Zitting uitslag op naam"
 
 #: ..\src\calcScore.cpp:238 ..\src\calcScore.cpp:1403
-msgid "Total result"
+msgid "Final result"
 msgstr "Totaal uitslag"
 
 #: ..\src\calcScore.cpp:242
@@ -255,9 +255,8 @@ msgstr "zitting"
 msgid "session on name"
 msgstr "zitting op naam"
 
-#. TRANSLATORS: "total", translation max length = 6
-#: ..\src\calcScore.cpp:298 ..\src\calcScore.cpp:1308
-msgid "total"
+#: ..\src\calcScore.cpp:298
+msgid "final"
 msgstr "totaal"
 
 #: ..\src\calcScore.cpp:304
@@ -269,8 +268,8 @@ msgid "club total"
 msgstr "club totaal"
 
 #: ..\src\calcScore.cpp:334 ..\src\main.cpp:932
-msgid "ERROR"
-msgstr "ERROR"
+msgid "Error"
+msgstr "Error"
 
 #: ..\src\calcScore.cpp:709
 #, c-format
@@ -371,7 +370,7 @@ msgstr " (gewogen gemiddelde)"
 
 #: ..\src\calcScore.cpp:1300
 #, c-format
-msgid "Total result%s"
+msgid "Final result%s"
 msgstr "Totaal uitslag%s"
 
 #: ..\src\calcScore.cpp:1302
@@ -382,6 +381,11 @@ msgstr "rang paarnaam                       "
 #, c-format
 msgid "  S%-4u"
 msgstr "  Z%-4u"
+
+#. TRANSLATORS: "total", translation max length = 6
+#: ..\src\calcScore.cpp:1308
+msgid "total"
+msgstr "totaal"
 
 #. TRANSLATORS: "avg.", translation max length = 4
 #: ..\src\calcScore.cpp:1310
@@ -1938,48 +1942,48 @@ msgstr ""
 "; syntax: <club nr> , <clubnaam>\n"
 "; lengte clubnaam maximaal %u karakters."
 
-#: ..\src\orgInterface.cpp:666 ..\src\utils.cpp:308
+#: ..\src\orgInterface.cpp:710 ..\src\utils.cpp:308
 msgid ": readerror"
 msgstr ": leesfout"
 
-#: ..\src\orgInterface.cpp:704
+#: ..\src\orgInterface.cpp:753
 msgid ": unknown type"
 msgstr ": onbekend type"
 
-#: ..\src\orgInterface.cpp:713
+#: ..\src\orgInterface.cpp:762
 msgid "Problem reading score-file"
 msgstr "Probleem bij inlezen score-file"
 
-#: ..\src\orgInterface.cpp:729
+#: ..\src\orgInterface.cpp:778
 msgid ": open error"
 msgstr ": openfout"
 
-#: ..\src\orgInterface.cpp:729
+#: ..\src\orgInterface.cpp:778
 msgid "Problem opening score-file"
 msgstr "Probleem bij openen score-file"
 
-#: ..\src\orgInterface.cpp:770 ..\src\utils.cpp:254 ..\src\utils.cpp:283
+#: ..\src\orgInterface.cpp:824 ..\src\utils.cpp:254 ..\src\utils.cpp:283
 msgid ": write error"
 msgstr ": schrijffout"
 
-#: ..\src\orgInterface.cpp:770
+#: ..\src\orgInterface.cpp:824
 msgid "Problem writing score-file"
 msgstr "Probleem bij wegschrijven score-file"
 
-#: ..\src\orgInterface.cpp:842 ..\src\orgInterface.cpp:944
+#: ..\src\orgInterface.cpp:896 ..\src\orgInterface.cpp:998
 #, c-format
 msgid "Unable to write corrections to: %s"
 msgstr "Kan korrecties niet wegschrijven naar: %s"
 
-#: ..\src\orgInterface.cpp:848
+#: ..\src\orgInterface.cpp:902
 msgid ";score.2 glbpair bonus.2 games   pairname"
 msgstr ";score.2 glbpaar bonus.2 spellen paarnaam"
 
-#: ..\src\orgInterface.cpp:951
+#: ..\src\orgInterface.cpp:1005
 msgid ";<correction><type> <session pairnr> <extra.1> <max extra> <pairname>"
 msgstr ";<correctie><type> <sessie paarnr> <extra.1> <max extra> <paarnaam>"
 
-#: ..\src\orgInterface.cpp:1016
+#: ..\src\orgInterface.cpp:1070
 msgid ";score 'glb pair' s<games>   name"
 msgstr ";score 'glb paar' s<spellen> naam"
 
@@ -2567,6 +2571,9 @@ msgstr "1 januari 2024"
 #: ..\src\version.h:15
 msgid "monday"
 msgstr "maandag"
+
+#~ msgid "ERROR"
+#~ msgstr "ERROR"
 
 #, fuzzy
 #~| msgid "Warning"

--- a/release/releasenotes.md
+++ b/release/releasenotes.md
@@ -6,6 +6,7 @@
  - added importing new playing schemas/movements
  - changed 'calculation program' to 'scoring program'
  - changed internal playing schemas/movements into an easier to read format
+ - decoupled old/global gameinfo
 
 #V10.4.0 Tuesday 4 March 2025
  - updated AutoHotkey64.exe from version 2.0.18 to 2.0.19

--- a/release/releasenotes.md
+++ b/release/releasenotes.md
@@ -6,7 +6,9 @@
  - added importing new playing schemas/movements
  - changed 'calculation program' to 'scoring program'
  - changed internal playing schemas/movements into an easier to read format
+ - stupid typo in IsInRange()
  - decoupled old/global gameinfo
+ - small texts update
 
 #V10.4.0 Tuesday 4 March 2025
  - updated AutoHotkey64.exe from version 2.0.18 to 2.0.19

--- a/release/releasenotes.md
+++ b/release/releasenotes.md
@@ -9,6 +9,7 @@
  - stupid typo in IsInRange()
  - decoupled old/global gameinfo
  - small texts update
+ - consequent use of wxString::IsEmpty() i.s.o wxString::empty()
 
 #V10.4.0 Tuesday 4 March 2025
  - updated AutoHotkey64.exe from version 2.0.18 to 2.0.19

--- a/release/releasenotes.md
+++ b/release/releasenotes.md
@@ -11,6 +11,8 @@
  - small texts update
  - consequent use of wxString::IsEmpty() i.s.o wxString::empty()
  - changed some wxStatictext to wxGenericStaticText to prevent clipping problems
+ - solved problem when .db was on a non-existing/non-writable location
+ - now current programversion is always updated in the datafiles
 
 #V10.4.0 Tuesday 4 March 2025
  - updated AutoHotkey64.exe from version 2.0.18 to 2.0.19

--- a/release/releasenotes.md
+++ b/release/releasenotes.md
@@ -10,6 +10,7 @@
  - decoupled old/global gameinfo
  - small texts update
  - consequent use of wxString::IsEmpty() i.s.o wxString::empty()
+ - changed some wxStatictext to wxGenericStaticText to prevent clipping problems
 
 #V10.4.0 Tuesday 4 March 2025
  - updated AutoHotkey64.exe from version 2.0.18 to 2.0.19

--- a/release/releasenotes.md
+++ b/release/releasenotes.md
@@ -13,6 +13,8 @@
  - changed some wxStatictext to wxGenericStaticText to prevent clipping problems
  - solved problem when .db was on a non-existing/non-writable location
  - now current programversion is always updated in the datafiles
+ - entry of scores can now also be done by contract i.s.o pure score-data
+ - updated wxWidgets to V3.2.7 (no changes compared to V3.2.6)
 
 #V10.4.0 Tuesday 4 March 2025
  - updated AutoHotkey64.exe from version 2.0.18 to 2.0.19

--- a/src/NewSchemaData.h
+++ b/src/NewSchemaData.h
@@ -25,7 +25,7 @@ public:
     NewSchemaDataType    rounds = 0;
     NewSchemaDataType    dummy  = 0;
     std::string name;
-    std::vector< std::vector<NewTableInfo> > tableData; // [rounds][table] NB 1-based: round 0 and table 0 are dummies!
+    std::vector< std::vector<NewTableInfo> > tableData; // [round][table] NB 1-based: round 0 and table 0 are dummies!
 };
 
 extern std::vector<const NEW_SCHEMA*> newSchemaTable;   // vector of pointers to schema's

--- a/src/baseframe.cpp
+++ b/src/baseframe.cpp
@@ -14,6 +14,7 @@
 #include "wx/combobox.h"
 #include "wx/regex.h"
 #include <wx/filepicker.h>
+#include <wx/generic/stattextg.h>
 
 #include "cfg.h"
 #include "baseframe.h"
@@ -154,7 +155,7 @@ wxBoxSizer* Baseframe::CreateSearchBox()
     m_pTxtCtrlSearchBox = new wxTextCtrl  (this, ID_BASEFRAME_SEARCH, Unique("SearchEntry"  ), wxDefaultPosition, wxDefaultSize, wxTE_PROCESS_ENTER);
     m_pTxtCtrlSearchBox->Clear();   // remove label-text from entry, but keep window-title for autotest...
     auto pButton        = new wxButton    (this, ID_BASEFRAME_SEARCH, Unique(_("Search"     )));
-    hSearchBox->Add(      new wxStaticText(this, wxID_ANY           , _("Text to search:")), TXT_CTRL_SIZER);
+    hSearchBox->Add(      new wxGenericStaticText(this, wxID_ANY    , _("Text to search:")), TXT_CTRL_SIZER);
     hSearchBox->Add(m_pTxtCtrlSearchBox , 0, wxRIGHT, 20);
     hSearchBox->Add(pButton             , 0);
 

--- a/src/baseframe.cpp
+++ b/src/baseframe.cpp
@@ -490,7 +490,7 @@ bool MyTextCtrl::IsMinusOk(const wxString& val, int pos) const
         return false;
 
     // And then only if there is no existing minus sign there.
-    if ( !val.empty() && val[0] == '-' )
+    if ( !val.IsEmpty() && val[0] == '-' )
         return false;
 
     // Notice that entering '-' can make our value invalid, for example if
@@ -519,7 +519,7 @@ bool MyTextCtrl::IsCharOk(const wxString& val, int pos, wxChar chr)
         }
 
         // Prepending a separator before the minus sign isn't allowed.
-        if ( pos == 0 && !val.empty() && val[0] == '-' )
+        if ( pos == 0 && !val.IsEmpty() && val[0] == '-' )
             return false;
 
         // Otherwise always accept it, adding a decimal separator doesn't

--- a/src/calcScore.cpp
+++ b/src/calcScore.cpp
@@ -1597,7 +1597,7 @@ void CalcScore::OnCalcResultPair(const wxCommandEvent& a_evt)
     long        score       = svSessionResult[pair].procentScore;
     wxString    corrections = GetSessionCorrectionString(pair);
     corrections.Replace(" ", ES, true);
-    if (!corrections.empty()) corrections = ' ' + corrections;
+    if (!corrections.IsEmpty()) corrections = ' ' + corrections;
     if (m_bButler)
     {
         ADDLINE(FMT(_("imps: %ld, games: %u, sessionscore: %s imps/game%s, rank: %u"),

--- a/src/calcScore.cpp
+++ b/src/calcScore.cpp
@@ -235,7 +235,7 @@ void CalcScore::ShowChoice()
             pTextFile = &m_txtFileResultOnName;
             break;
         case ResultTotal:
-            title = _("Total result");
+            title = _("Final result");
             pTextFile = &m_txtFileResultTotal;
             break;
         case ResultFrqTable:
@@ -295,7 +295,7 @@ void CalcScore::RefreshInfo()
     // now add dynamic parts
     if ( cfg::GetActiveSession() != 0)
     {
-        choices.push_back(_("total"));
+        choices.push_back(_("final"));
         m_vChoices.push_back(ResultTotal);
     }
     // club related parts
@@ -331,7 +331,7 @@ void CalcScore::RefreshInfo()
     Layout();
     if (FindBadGameData())
     {   // show messagebox on top of the result
-        CallAfter([this] {MyMessageBox(m_txtBadGameData, _("ERROR")); });
+        CallAfter([this] {MyMessageBox(m_txtBadGameData, _("Error")); });
     }
 }   // RefreshInfo()
 
@@ -1297,7 +1297,7 @@ void CalcScore::CalcTotal()
 
     m_txtFileResultTotal.MyCreate(cfg::ConstructFilename(cfg::EXT_RESULT_TOTAL), MyTextFile::WRITE);
     m_txtFileResultTotal.AddLine(cfg::GetDescription());
-    m_txtFileResultTotal.AddLine(FMT(_("Total result%s"), bWeightedAvg ? _(" (weighted average)") : ES));
+    m_txtFileResultTotal.AddLine(FMT(_("Final result%s"), bWeightedAvg ? _(" (weighted average)") : ES));
     m_txtFileResultTotal.AddLine(ES);
     wxString tmp = _("rank pairname                       ");
     for (session=1; session <= maxSession; ++session)
@@ -1400,7 +1400,7 @@ void CalcScore::CalcClub( bool a_bTotal)
     MyTextFile&         txtFile     = a_bTotal ? m_txtFileResultClubTotal : m_txtFileResultClubSession;
     UINT                session     = cfg::GetActiveSession();
     UINT                maxSession  = a_bTotal ? session : 1;
-    wxString            header      = a_bTotal ? _("Total result") : session ? FMT(_("Result of session %u"), session): _("Session result");
+    wxString            header      = a_bTotal ? _("Final result") : session ? FMT(_("Result of session %u"), session): _("Session result");
     wxString            fileName    = cfg::ConstructFilename(a_bTotal ? cfg::EXT_CLUB_TOTAL : cfg::EXT_SESSION_CLUB);
 
     std::vector<CLUB_DATA> club;

--- a/src/calcScore.cpp
+++ b/src/calcScore.cpp
@@ -347,7 +347,7 @@ void CalcScore::PrintPage()
     for (int line = 0; line < itemCount; ++line)
     {
         wxString info = m_pListBox->GetItemText(line);
-        if (info.IsEmpty() || '\n' != info.Last()) info += '\n';    // Last()== *info.rbegin()
+        if (info.IsEmpty() || '\n' != *info.rbegin()) info += '\n';    // Last()== *info.rbegin()
         prn::PrintLine(info);
     }
 

--- a/src/cfg.cpp
+++ b/src/cfg.cpp
@@ -43,7 +43,7 @@ namespace cfg
     static const wxString   ssGlobalNameFile ("globalNames.db");    // db-filename when using global names
     static wxString         ssBaseFolder;           // folder where bridge.ini/globalNames.db is located
 
-    static wxString         ssVersion;              // version string in (all) the ini-files
+
     static wxString         ssActiveMatch;          // base-name of the active match, used in filenames. Must be inited here!
     static wxString         ssActiveMatchPath;      // location of match-data
     static wxString         ssMatchIni;             // = "default.ini";
@@ -699,7 +699,7 @@ namespace cfg
                 return CFG_ERROR;
         }
 
-        ssVersion     = io::ReadValue(KEY_PRG_VERSION   , ssVersion );
+        io::WriteValue(KEY_PRG_VERSION, GetVersion());
         ssDescription = io::ReadValue(KEY_SESSION_DISCR , ssDescription, suSession );
         return io::SchemaRead (sSessionInfo, suSession );
     }   // UpdateConfigSession()
@@ -712,7 +712,7 @@ namespace cfg
             return CFG_ERROR;
         }
 
-        ssVersion       = io::ReadValue     (KEY_PRG_VERSION     , GetVersion()      );
+        io::WriteValue(KEY_PRG_VERSION, GetVersion());
         ssComment       = io::ReadValue     (KEY_MATCH_CMNT      , GetCopyright()    );
         (void)            io::ReadValue     (KEY_MATCH_DISCR     , ssDescription     );
 
@@ -752,9 +752,7 @@ namespace cfg
             spConfigMain->SetRecordDefaults();   //write all requested entries to the file, if not present
         }
 
-        siLanguage        = spConfigMain->Read(CFG_MAIN_LANGUAGE, siLanguage);
-        (void)              spConfigMain->Read(CFG_MAIN_LANGUAGE_DESCRIPTION, "default");
-        ssVersion         = spConfigMain->Read(CFG_MAIN_VERSION, GetVersion());
+        spConfigMain->Write(CFG_MAIN_VERSION, GetVersion());
         wxString tmp      = GetActiveMatchPath() + GetActiveMatch();  // base+name....
         wxFileName tmp2   = spConfigMain->Read(CFG_MAIN_GAME, tmp);
         ssActiveMatch     = tmp2.GetFullName();
@@ -769,6 +767,8 @@ namespace cfg
             (void)spConfigMain->Write(CFG_MAIN_GAME, tmp);
         }
 
+        siLanguage        = spConfigMain->Read(CFG_MAIN_LANGUAGE, siLanguage);
+        (void)              spConfigMain->Read(CFG_MAIN_LANGUAGE_DESCRIPTION, "default");
         slActiveDbType    = static_cast<io::ActiveDbType>(spConfigMain->Read(CFG_MAIN_DBTYPE, slActiveDbType));
         io::DatabaseTypeSet(static_cast<io::ActiveDbType>(slActiveDbType), true);  // silently set db-type
 

--- a/src/cfg.cpp
+++ b/src/cfg.cpp
@@ -372,7 +372,7 @@ namespace cfg
     void SetActiveMatch(const wxString& a_sMatch, const wxString& a_sMatchPath)
     {
         if (    ( ssActiveMatch == a_sMatch )
-             && ( !a_sMatchPath.empty() && (a_sMatchPath == ssActiveMatchPath))
+             && ( !a_sMatchPath.IsEmpty() && (a_sMatchPath == ssActiveMatchPath))
            ) return;
 
         ssActiveMatch     = a_sMatch;
@@ -677,7 +677,7 @@ namespace cfg
     void SetPrinterName( const wxString& a_printer)
     {
         wxString tmp;
-        if (a_printer.empty())
+        if (a_printer.IsEmpty())
             tmp = FILE_PRINTER_NAME;
         else
             tmp = a_printer;

--- a/src/correctionsEnd.cpp
+++ b/src/correctionsEnd.cpp
@@ -88,7 +88,7 @@ void CorrectionsEnd::AutotestRequestMousePositions(MyTextFile* a_pFile)
         if (score.IsEmpty() && bonus.IsEmpty()) continue;
             
         cor::CORRECTION_END cor;
-        if (score.empty())
+        if (score.IsEmpty())
         {   // we only have a bonus
             cor.score = SCORE_IGNORE;
             cor.bonus = AsciiTolong(bonus, ExpectedDecimalDigits::DIGITS_2);
@@ -145,7 +145,7 @@ bool CorrectionsEnd::OnCellChanging(const CellInfo& a_cellInfo)
     if (col == COL_COR_GAMES)
     {   // only acceptable if we have a non-empty real score
         wxString score = m_theGrid->GetCellValue(row, COL_COR_SCORE);
-        if (score.empty() || score[0] == '-' || score[0] == '*' )
+        if (score.IsEmpty() || score[0] == '-' || score[0] == '*' )
             return CELL_CHANGE_REJECTED;
     }
     else
@@ -156,7 +156,7 @@ bool CorrectionsEnd::OnCellChanging(const CellInfo& a_cellInfo)
             m_theGrid->SetCellValue(row, COL_COR_GAMES, ES);
         }
         else
-            if ( (col == COL_COR_SCORE) && newData.empty() )
+            if ( (col == COL_COR_SCORE) && newData.IsEmpty() )
             {   // only bonus column is needed
                 m_theGrid->SetCellValue(row, COL_COR_GAMES, ES);
             }
@@ -167,7 +167,7 @@ bool CorrectionsEnd::OnCellChanging(const CellInfo& a_cellInfo)
                 long value = AsciiTolong( newData, ExpectedDecimalDigits::DIGITS_2);
                 if ( (value >= minimum) && (value <= 10000) )
                 {   // if inrange, show data
-                    if (col == COL_COR_BONUS && (value == 0 || !m_theGrid->GetCellValue(row, COL_COR_SCORE).empty()))
+                    if (col == COL_COR_BONUS && (value == 0 || !m_theGrid->GetCellValue(row, COL_COR_SCORE).IsEmpty()))
                     {
                         ;
                     }

--- a/src/correctionsSession.cpp
+++ b/src/correctionsSession.cpp
@@ -214,7 +214,7 @@ bool CorrectionsSession::OnCellChanging(const CellInfo& a_cellInfo)
         case COL_COR_EXTRA:
             if (m_bButler)
             {
-                if (newData.IsEmpty())    // remove combi-table data
+                if (newData.IsEmpty())      // remove combi-table data
                     m_theGrid->SetCellValue(row, COL_COR_GAMES, ES);
                 else
                 {

--- a/src/correctionsSession.cpp
+++ b/src/correctionsSession.cpp
@@ -180,7 +180,7 @@ bool CorrectionsSession::OnCellChanging(const CellInfo& a_cellInfo)
     switch (col)
     {
         case COL_COR_PROCENT:
-            if (!newData.empty())
+            if (!newData.IsEmpty())
             {
                 m_theGrid->SetCellValue(row, COL_COR_MP, ES);
                 if ( value == 0 || value == COR_PERCENT_MIN)    // you get minimum if there is rubbisch in the cell ....
@@ -188,7 +188,7 @@ bool CorrectionsSession::OnCellChanging(const CellInfo& a_cellInfo)
             }
             break;
         case COL_COR_MP:
-            if (!newData.empty())
+            if (!newData.IsEmpty())
             {
                 m_theGrid->SetCellValue(row, COL_COR_MP , ES);
                 if ( value == 0 || value == COR_MP_MIN)         // you get minimum if there is rubbisch in the cell ....
@@ -196,7 +196,7 @@ bool CorrectionsSession::OnCellChanging(const CellInfo& a_cellInfo)
             }
             break;
         case COL_COR_MAX:
-            if (newData.empty() || 0 == value)
+            if (newData.IsEmpty() || 0 == value)
             {
                 m_theGrid->SetCellValue(row, COL_COR_EXTRA, ES);
                 m_theGrid->SetCellValue(row, COL_COR_GAMES, ES);
@@ -207,34 +207,34 @@ bool CorrectionsSession::OnCellChanging(const CellInfo& a_cellInfo)
                 if ( value < COR_EXTRA_MIN) value = COR_EXTRA_MIN;
                 if ( value > COR_EXTRA_MAX) value = COR_EXTRA_MAX;
                 m_theGrid->SetCellValue(row, COL_COR_EXTRA, ForceInRange( m_theGrid->GetCellValue(row,COL_COR_EXTRA), COR_EXTRA_MIN, value*10));
-                if (m_theGrid->GetCellValue(row, COL_COR_GAMES).empty())
+                if (m_theGrid->GetCellValue(row, COL_COR_GAMES).IsEmpty())
                     m_theGrid->SetCellValue(row, COL_COR_GAMES, U2String(cfg::GetSetSize()));
             }
             break;
         case COL_COR_EXTRA:
             if (m_bButler)
             {
-                if (newData.empty())    // remove combi-table data
+                if (newData.IsEmpty())    // remove combi-table data
                     m_theGrid->SetCellValue(row, COL_COR_GAMES, ES);
                 else
                 {
                     wxString validated = ForceInRange(newData, -100, 100, true);
                     m_theGrid->CallAfter([this,row,col,validated](){this->m_theGrid->SetCellValue(row, col, validated);});
-                    if (m_theGrid->GetCellValue(row, COL_COR_GAMES).empty())    // set default set-size
+                    if (m_theGrid->GetCellValue(row, COL_COR_GAMES).IsEmpty())    // set default set-size
                         m_theGrid->SetCellValue(row, COL_COR_GAMES, U2String(cfg::GetSetSize()));
                 }
             }
             else  // percent scoring
-            if (!newData.empty())
+            if (!newData.IsEmpty())
             {
-                if (m_theGrid->GetCellValue(row,COL_COR_MAX).empty())
+                if (m_theGrid->GetCellValue(row,COL_COR_MAX).IsEmpty())
                     return CELL_CHANGE_REJECTED;        // only extra-data if we have a maximum inserted
                 wxString extra = ForceInRange(newData, COR_EXTRA_MIN, 10*wxAtoi(m_theGrid->GetCellValue(row,COL_COR_MAX)));
                 m_theGrid->CallAfter([this,row,col,extra](){this->m_theGrid->SetCellValue(row, col, extra);});
             }
             break;
         case COL_COR_GAMES:
-            if (m_theGrid->GetCellValue(row,COL_COR_MAX).empty() && m_theGrid->GetCellValue(row,COL_COR_EXTRA).empty())
+            if (m_theGrid->GetCellValue(row,COL_COR_MAX).IsEmpty() && m_theGrid->GetCellValue(row,COL_COR_EXTRA).IsEmpty())
                 return CELL_CHANGE_REJECTED;        // only games if extra/max data
             break;
         default:

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -151,12 +151,12 @@ CfgFileEnum DatabaseOpen(io::GlbDbType /*dbType*/, CfgFileEnum a_how2Open)
         (void)db.Mkdir(wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL);     // create full path, no error if allready there
     if (!db.IsDirWritable())
     {
-        // if not writable, select "C:\\Users\\<me>\\AppData\\Local\\BridgeWx" dir
-        wxString err = db.GetFullPath() + _(": is not accessable!");
+        // if not writable, select "<documents_dir>/BridgeWx" folder
+        wxString err = db.GetFullPath() + _(": is not accessable!\nPath set to: ") + cfg::GetBaseFolder();
         MyLogError( err );      // wxLogError will stop the programm with a pop-up...
         MyMessageBox(err);
         wxString dir = cfg::GetBaseFolder();
-        cfg::SetActiveMatch(db.GetFullName(), dir);
+        cfg::SetActiveMatch(db.GetName(), dir); //NB, no extension!
         db = wxFileName(dir, db.GetFullName());
     }
 

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -106,7 +106,7 @@ static wxFileConfig* InitDatabase(const wxString& a_dbFile)
         file.AddLine(";info database           : 'data saved according definition of version <x>'");
         file.AddLine(";info pair names         : '<global pairnr> = {<name>,<clubId>}, max size=30'");
         file.AddLine(";info club names         : '<club id> = \"club name\", max size=25'");
-        file.AddLine(";info game result        : '<game nr> = {<ns>,<ew>,<ns result>,<ew result>}[@ ...]'");
+        file.AddLine(";info game result        : '<game nr> = {<ns>,<ew>,<ns result>,<ew result>[,\"ns contract\",\"ew contract\"]}[@ ...]'");
         file.AddLine(";info schema             : '{<nr of games>,<setsize>,<first game>}@{<nr of pairs>,<absent pair>,\"schema\",\"groupChars\"}[@...]'");
         file.AddLine(";info min/max club       : '{<min pairs needed>,<max pairs used>}'");
         file.AddLine(";info assignments        : '<global pairnr>[@...] -> array[<sessionpair>] = <global pairnr>'");
@@ -281,6 +281,17 @@ bool ClubnamesWrite(const std::vector<wxString>& clubNames)
     return bResult;
 } // ClubnamesWrite()
 
+static char* TrimContract(char contract[])
+{   // remove spaces and '"' at end of input
+    size_t len = strlen(contract);
+    while (len && (contract[len - 1] == ' ' || contract[len - 1] == '"'))
+    {
+        --len;
+        contract[len] = 0;
+    }
+    return contract;
+}   // TrimContract()
+
 bool ScoresRead(vvScoreData& scoreData, UINT session)
 {
     scoreData.clear();                  // remove old data
@@ -299,10 +310,20 @@ bool ScoresRead(vvScoreData& scoreData, UINT session)
         score::GameSetData setData;
         for (const auto& it : splitValues)
         {
-            char nsScore[10]={0};
-            char ewScore[10]={0};
-            auto count = wxSscanf(it," { %u , %u, %9[^, ] , %9[^} ] }", &setData.pairNS, &setData.pairEW, nsScore, ewScore);
-            if (count != 4)
+            char nsScore   [10] = {0};  // {1,2,'score','score'} or {1,2,'score','score',"nsContract","ewContract"} 
+            char ewScore   [10] = {0};
+            char nsContract[20] = {0};
+            char ewContract[20] = {0};
+
+            // OK, so sscanf fails if the string to read is empty! Solution: read string INCLUSIVE closing quote!
+            auto count = wxSscanf(it," { %u , %u, %9[^, ] , %9[^} ,] , \"%19[^,], \"%19[^}]}"
+                , &setData.pairNS, &setData.pairEW, nsScore, ewScore, nsContract, ewContract);
+            if (count == 6) // we have also read two biddings
+            {   // remove possible spaces and '"' at end of input
+                setData.contractNS = TrimContract(nsContract);
+                setData.contractEW = TrimContract(ewContract);
+            }
+            if (count != 4 && count != 6)
             {
                 MyLogError(_("Reading scores: game %u: <%s> invalid!"), game, it);
                 continue;
@@ -332,8 +353,11 @@ bool ScoresWrite(const vvScoreData& scoreData, UINT session)
             wxChar separator = ' ';
             for (auto score : it)
             {
-                theScores += FMT("%c{%u,%u,%s,%s}", separator, score.pairNS, score.pairEW,
-                        score::ScoreToString(score.scoreNS), score::ScoreToString(score.scoreEW));
+                wxString contracts;
+                if (!score.contractNS.IsEmpty() || !score.contractEW.IsEmpty())
+                    contracts = FMT(",\"%s\",\"%s\"", score.contractNS, score.contractEW);
+                theScores += FMT("%c{%u,%u,%s,%s%s}", separator, score.pairNS, score.pairEW,
+                        score::ScoreToString(score.scoreNS), score::ScoreToString(score.scoreEW), contracts);
                 separator = theSeparator;
             }
             if (!s_pConfig->Write(FMT("%u", game), theScores))

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -859,12 +859,6 @@ static void SkipDigits(const wxChar* &pBuf)       // skip digits
     SkipWhite(pBuf);
 }   // SkipDigits()
 
-static void SkipChars(const wxChar* &pBuf)        // skip alpha
-{
-    while (std::isalpha(*pBuf)) pBuf++;
-    SkipWhite(pBuf);
-}   // SkipChars()
-
 UINT Debug::AtoiRound(const wxChar * pBuf)
 {
     UINT round = wxAtoi(pBuf);   // 'wide' atoi
@@ -1440,184 +1434,26 @@ void Debug::DoCommand(const wxString& a_cmd)
 
 void Debug::CalcScore(const wxChar* pBuf)
 {
-    enum CardTypes
+    wxString resultAsString;
+    int scoreNv = score::GetContractScoreFromString(pBuf, false, resultAsString);
+    OUTPUT_TEXT(resultAsString);
+    switch (scoreNv)
     {
-        CLUBS       = 0
-      , HEARTS      = 1
-      , NO_TRUMP    = 2
-    };
-
-    const char*  doubledStrings [] = {"", _(" doubled"), _(" re-doubled")};
-    const char*  contractType   [] = {_("clubs/diamonts"), _("hearts/spades"), _("no trump")};
-    static int const   typeValue[] = { 20                 , 30                  , 30 };
-    int     type        = 0;    // clubs/diamonds = 0, hearts/spades=1,no-trump=2
-    int     doubled     = 0;
-    int     contract    = 7;    // if only down-tricks, default to 7
-    int     tricks      = 0;
-    int     vulnerableScore;
-    int     nonVulnerableScore;
-
-    //lint --e{438}    Last value assigned to variable 'buf' not used
-    if (isdigit(*pBuf))
-    {
-        contract = wxAtoi(pBuf);      // determine the bid
-        SkipDigits(pBuf);           // skip digits
-        switch (*pBuf)
-        {
-            case 'K': case 'R':
-                type = CLUBS;
-                break;
-            case 'H':
-                type = HEARTS;
-                break;
-            case 'S':
-                if (pBuf[1] == 'A')  // did you mean no-trump??
-                    type = NO_TRUMP;
-                else
-                    type = HEARTS;  // s of spades.....
-                break;
-            case 'Z':
-                type = NO_TRUMP;
-                break;
-            default:
-                Usage();
-                return;
-        }
-        SkipChars(++pBuf);
-        if (*pBuf == '*'){++doubled; SkipWhite(++pBuf);} // doubled score
-        if (*pBuf == '*'){++doubled; ++pBuf;}            // re-doubled score
-        if (*pBuf)
-        {
-            SkipWhite(pBuf);
-            tricks = wxAtoi(pBuf);
-            SkipDigits(++pBuf);
-            if (*pBuf == '*'){++doubled; SkipWhite(++pBuf);}
-            if (*pBuf == '*'){++doubled; ++pBuf;}
-            if (doubled > 2) doubled = 2;     // more then ** not possible...
-        }
-    }
-    else
-    {
-        if (*pBuf == '-')                    // only down-tricks
-        {
-            tricks = wxAtoi(pBuf);
-            if (tricks == 0) { Usage(); return;}    // '-0' ????
-            SkipDigits(++pBuf);
-            if (*pBuf == '*'){++doubled; SkipWhite(++pBuf);}
-            if (*pBuf == '*'){++doubled; /*++pBuf;*/ }
-        }
-        else
-        {
+        case 0:     // contract values not consistent, error already shown through 'resultAsString'
+            break;
+        case -1:    // bad contract description (empty 'resultAsString')
             Usage();
-            return;
+            break;
+        default:
+        {           // we have a good result, show it
+            int scoreV = score::GetContractScoreFromString(pBuf, true,  resultAsString);
+            OUTPUT_TEXT_FORMATTED(_(", score vulnerable: %i, not vulnerable: %i\n"), scoreV, scoreNv);
         }
     }
-
-    // type and count are determined
-    // now calculate score
-    if (tricks < 0)     // down
-    {
-        if (contract + 6 + tricks < 0)
-        {
-            OUTPUT_TEXT(_("more down then contract-tricks??\n"));
-            return;
-        }
-        tricks = -tricks;
-        OUTPUT_TEXT_FORMATTED(_("%d down %s, "), tricks, doubledStrings[doubled]);
-        if (doubled == 0)
-        {
-            vulnerableScore    = 100*tricks;
-            nonVulnerableScore =  50*tricks;
-        }
-        else
-        {
-            vulnerableScore = tricks*300-100;
-            if (tricks >= 4)
-                nonVulnerableScore = 800+300*(tricks-4);
-            else
-                nonVulnerableScore = 200*tricks-100;
-        }
-        vulnerableScore    = -vulnerableScore;
-        nonVulnerableScore = -nonVulnerableScore;
-        if (doubled == 2)
-        {
-            vulnerableScore    *= 2;
-            nonVulnerableScore *= 2;
-        }
-    }
-    else
-    {
-        if (contract + 6 + tricks > 13)
-        {
-            OUTPUT_TEXT(_("more tricks then possible in a game??\n"));
-            return;
-        }
-        OUTPUT_TEXT_FORMATTED("%d %s%+d%s, ",
-            contract,       contractType[type],
-            tricks,     doubledStrings[doubled]);
-        switch (contract)
-        {
-            case 7:
-                vulnerableScore     = 2000; nonVulnerableScore = 1300;
-                break;
-            case 6: vulnerableScore = 1250; nonVulnerableScore = 800;
-                break;
-            case 5: vulnerableScore =  500; nonVulnerableScore = 300;
-                break;
-            case 4:
-                if ((type != CLUBS) || doubled)
-                {
-                    vulnerableScore = 500; nonVulnerableScore = 300;
-                }
-                else
-                {
-                    vulnerableScore = 50; nonVulnerableScore = 50;
-                }
-                break;
-            case 3:
-                if (doubled || (type == NO_TRUMP) )
-                {   vulnerableScore = 500; nonVulnerableScore = 300;}
-                else
-                {   vulnerableScore =  50; nonVulnerableScore =  50;}
-                 break;
-            case 2:
-                if ((doubled && (type != CLUBS)) || (doubled == 2))
-                {   vulnerableScore = 500; nonVulnerableScore = 300;}
-                else
-                {   vulnerableScore =  50; nonVulnerableScore =  50;}
-                break;
-            default:    // not possible...
-            case 1:
-                if ((doubled == 2) && (type != CLUBS))
-                {   vulnerableScore = 500; nonVulnerableScore = 300;}
-                else
-                {   vulnerableScore =  50; nonVulnerableScore =  50;}
-                break;
-        }
-        int trickValue;
-        if (type == NO_TRUMP)
-            trickValue = 10+5*doubled*(1+doubled);    // 10, 20, 40
-        else
-            trickValue = 0;
-        switch (doubled)
-        {
-            case 0: trickValue += (contract+tricks)*typeValue[type];
-                break;
-            case 1: nonVulnerableScore += tricks*100;
-                vulnerableScore += tricks*200;
-                trickValue +=  50+2*contract*typeValue[type];
-                break;
-            case 2: nonVulnerableScore += tricks*200;
-                vulnerableScore += tricks*400;
-                trickValue += 100+4*contract*typeValue[type];
-                break;
-            default:
-                break;
-        }
-        vulnerableScore    += trickValue;
-        nonVulnerableScore += trickValue;
-    }   // end not down
-    OUTPUT_TEXT_FORMATTED(_("score vulnerable: %d, not vulnerable: %d\n"), vulnerableScore, nonVulnerableScore);
+    #define CALC_OLD 0
+    #if CALC_OLD
+        CalcScoreOld(pBuf); // use (also) 'old' result calculation
+    #endif
 }   // CalcScore()
 
 void Debug::Usage()
@@ -1630,10 +1466,20 @@ void Debug::Usage()
             "   gx        = go to group x\n"
             "   n         = yes<->no testing of setentry\n"
             "   d         = debug: test schema's\n"
-            "   x k|r|h|s|z [*[*]] [[+|-]y]: calculate score for 'x' clubs/diamonds/hearts/spades/no-trump\n"
-            "               with 'y' up/down-tricks [[re]doubled]\n"
             "   o         = overview active schema\n"
+            "   -x[*[*]] or y'SUIT'[[+|-]x][*[*]]   calculate the score for:\n"
+            "             'x'    = the number of over/under tricks.\n"
+            "             'y'    = the level of the contract.\n"
+            "             'SUIT' = the type of the contract (or, when abbreviated, the first match in the card-names)\n"
+            "             '*'    = doubled, and '**' is redoubled\n"
     );
+    sp += FMT("             %s:", _("SUIT"));
+    for (int index = score::CardId::CardIdFirst; index <= score::CardId::CardIdLast; ++index)
+    {   // can't use 'score::CardId' for index: it doesn't go above last typevalue! (I made it so!)
+        sp += FMT(" '%s' |",  score::GetCardName(static_cast<score::CardId>(index)));
+    }
+    sp.RemoveLast();    // == '|'
+    sp += '\n';
 
     OUTPUT_TEXT(sp);
 }   // Usage()
@@ -2280,3 +2126,195 @@ void Debug::PrintSchemaOverviewNew()
     myPrint.PrintTable(tableInfo);      // print current guide
     myPrint.EndPrint();
 }   // PrintSchemaOverviewNew()
+
+#if CALC_OLD
+static void SkipChars(const wxChar* &pBuf)        // skip alpha
+{
+    while (std::isalpha(*pBuf)) pBuf++;
+    SkipWhite(pBuf);
+}   // SkipChars()
+
+void Debug::CalcScoreOld(const wxChar* pBuf)
+{
+    enum CardTypes
+    {
+        CLUBS       = 0
+        , HEARTS      = 1
+        , NO_TRUMP    = 2
+    };
+
+    const char*  doubledNames     [] = {"", _("doubled"), _("redoubled")};
+    const char*  contractTypeNames[] = {_("Clubs/Diamonds"), _("Hearts/Spades"), _("NoTrump")};
+    static int const   typeValue  [] = { 20                 , 30                  , 30 };
+    int     type        = 0;    // clubs/diamonds = 0, hearts/spades=1,no-trump=2
+    int     doubled     = 0;
+    int     contract    = 7;    // if only down-tricks, default to 7
+    int     tricks      = 0;
+    int     vulnerableScore;
+    int     nonVulnerableScore;
+
+    //lint --e{438}    Last value assigned to variable 'buf' not used
+    if (isdigit(*pBuf))
+    {
+        contract = wxAtoi(pBuf);    // determine the bid
+        SkipDigits(pBuf);           // skip digits
+        switch (*pBuf)
+        {
+        case 'K': case 'R':
+            type = CLUBS;
+            break;
+        case 'H':
+            type = HEARTS;
+            break;
+        case 'S':
+            if (pBuf[1] == 'A')  // did you mean no-trump??
+                type = NO_TRUMP;
+            else
+                type = HEARTS;  // s of spades.....
+            break;
+        case 'Z':
+            type = NO_TRUMP;
+            break;
+        default:
+            Usage();
+            return;
+        }
+        SkipChars(++pBuf);
+        if (*pBuf == '*'){++doubled; SkipWhite(++pBuf);} // doubled score
+        if (*pBuf == '*'){++doubled; ++pBuf;}            // redoubled score
+        if (*pBuf)
+        {
+            SkipWhite(pBuf);
+            tricks = wxAtoi(pBuf);
+            SkipDigits(++pBuf);
+            if (*pBuf == '*'){++doubled; SkipWhite(++pBuf);}
+            if (*pBuf == '*'){++doubled; ++pBuf;}
+        }
+    }
+    else
+    {
+        if (*pBuf == '-')                    // only down-tricks
+        {
+            tricks = wxAtoi(pBuf);
+            if (tricks == 0) { Usage(); return;}    // '-0' ????
+            SkipDigits(++pBuf);
+            if (*pBuf == '*'){++doubled; SkipWhite(++pBuf);}
+            if (*pBuf == '*'){++doubled; /*++pBuf;*/ }
+        }
+        else
+        {
+            Usage();
+            return;
+        }
+    }
+
+    // type and count are determined
+    // now calculate score
+    if (doubled > 2) doubled = 2;     // more then ** not possible...
+    if (tricks < 0)     // down
+    {
+        if (contract + 6 + tricks < 0)
+        {
+            OUTPUT_TEXT(_("more down then contract-tricks??\n"));
+            return;
+        }
+        tricks = -tricks;
+        wxString sDbl = FMT(_("%i down %s"), tricks, doubledNames[doubled]);
+        OUTPUT_TEXT(sDbl.Trim(true));
+        if (doubled == 0)
+        {
+            vulnerableScore    = 100*tricks;
+            nonVulnerableScore =  50*tricks;
+        }
+        else
+        {
+            vulnerableScore = tricks*300-100;
+            if (tricks >= 4)
+                nonVulnerableScore = 800+300*(tricks-4);
+            else
+                nonVulnerableScore = 200*tricks-100;
+        }
+        vulnerableScore    = -vulnerableScore;
+        nonVulnerableScore = -nonVulnerableScore;
+        if (doubled == 2)
+        {
+            vulnerableScore    *= 2;
+            nonVulnerableScore *= 2;
+        }
+    }
+    else
+    {
+        if (contract + 6 + tricks > 13)
+        {
+            OUTPUT_TEXT(_("more tricks then possible in a game??\n"));
+            return;
+        }
+        wxString sDoubled = FMT(" %s", doubledNames[doubled]); sDoubled.Trim(true); // if not (re-)doubled, remove space
+        OUTPUT_TEXT_FORMATTED("%d %s %+d%s",
+            contract, contractTypeNames[type],
+            tricks,   sDoubled);
+        switch (contract)
+        {
+            case 7:
+                vulnerableScore     = 2000; nonVulnerableScore = 1300;
+                break;
+            case 6: vulnerableScore = 1250; nonVulnerableScore = 800;
+                break;
+            case 5: vulnerableScore =  500; nonVulnerableScore = 300;
+                break;
+            case 4:
+                if ((type != CLUBS) || doubled)
+                {
+                    vulnerableScore = 500; nonVulnerableScore = 300;
+                }
+                else
+                {
+                    vulnerableScore = 50; nonVulnerableScore = 50;
+                }
+                break;
+            case 3:
+                if (doubled || (type == NO_TRUMP) )
+                {   vulnerableScore = 500; nonVulnerableScore = 300;}
+                else
+                {   vulnerableScore =  50; nonVulnerableScore =  50;}
+                break;
+            case 2:
+                if ((doubled && (type != CLUBS)) || (doubled == 2))
+                {   vulnerableScore = 500; nonVulnerableScore = 300;}
+                else
+                {   vulnerableScore =  50; nonVulnerableScore =  50;}
+                break;
+            default:    // not possible...
+            case 1:
+                if ((doubled == 2) && (type != CLUBS))
+                {   vulnerableScore = 500; nonVulnerableScore = 300;}
+                else
+                {   vulnerableScore =  50; nonVulnerableScore =  50;}
+                break;
+        }
+        int trickValue;
+        if (type == NO_TRUMP)
+            trickValue = 10+5*doubled*(1+doubled);    // 10, 20, 40
+        else
+            trickValue = 0;
+        switch (doubled)
+        {
+            case 0: trickValue += (contract+tricks)*typeValue[type];
+                break;
+            case 1: nonVulnerableScore += tricks*100;
+                vulnerableScore += tricks*200;
+                trickValue +=  50+2*contract*typeValue[type];
+                break;
+            case 2: nonVulnerableScore += tricks*200;
+                vulnerableScore += tricks*400;
+                trickValue += 100+4*contract*typeValue[type];
+                break;
+            default:
+                break;
+        }
+        vulnerableScore    += trickValue;
+        nonVulnerableScore += trickValue;
+    }   // end not down
+    OUTPUT_TEXT_FORMATTED(_(", score vulnerable: %i, not vulnerable: %i\n"), vulnerableScore, nonVulnerableScore);
+}   // CalcScoreOld()
+#endif

--- a/src/debug.h
+++ b/src/debug.h
@@ -34,6 +34,7 @@ private:
     void HandleCommandLine      (wxString cmdLine);
     void DoCommand              (const wxString& cmd);
     void CalcScore              (const wxChar* pBuf);
+    void CalcScoreOld           (const wxChar* pBuf);
     void List                   (const wxChar* pBuf);
     void GuideCard              (UINT pair, bool bAskExtra = true);
     void Usage                  ();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -929,7 +929,7 @@ void MyFrame::OnImportSchema(wxCommandEvent& )
         {
             wxString error(_("Don't import a schema from the basefolder itself!"));
             MyLogError(error);
-            MyMessageBox(error, _("ERROR"));
+            MyMessageBox(error, _("Error"));
         } else
         {   // only import if folders are different!
             if (schema::ImportSchema(schemaFile, true))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -430,6 +430,7 @@ void MyApp::ReInitLanguage()
     else
         MyLogMessage(_("Systemlanguage: the default system language"));
 
+    score::InitTexts4Translation(true);   // force re-init of static texts for translation
 }   // ReInitLanguage()
 
 bool MyApp::OnInit()

--- a/src/mygrid.cpp
+++ b/src/mygrid.cpp
@@ -100,7 +100,7 @@ void MyGrid::OnCellChanging(wxGridEvent& a_event)
 bool MyGrid::Search(const wxString& a_s2Search )
 {
     int rows = GetNumberRows();
-    if ((rows == 0) || a_s2Search.empty()) return false;      // no data to search for
+    if ((rows == 0) || a_s2Search.IsEmpty()) return false;      // no data to search for
 
     wxString search(a_s2Search);
     search.MakeLower();

--- a/src/nameEditor.cpp
+++ b/src/nameEditor.cpp
@@ -109,7 +109,7 @@ bool NameEditor::OnCellChanging(const CellInfo& a_cellInfo)
     {
         wxString    newName = a_cellInfo.newData;
         int         clubId  = wxAtoi(m_theGrid->GetCellValue (row, COL_CLUBID));
-        if (newName.empty())
+        if (newName.IsEmpty())
         {   // remove club info for this pair
             m_theGrid->SetCellValue (row, COL_CLUBID, ES);
         }
@@ -214,7 +214,7 @@ void NameEditor::AddName(const wxString& a_pairName, const wxString& a_clubName,
     if (count < cfg::MAX_PAIRS)
     {
         m_theGrid->AppendRows(1);
-        if ( a_pairName.empty() )
+        if ( a_pairName.IsEmpty() )
         {
             m_theGrid->SetCellValue(count, COL_PAIRNAME, FMT(_("pair %d"), count + 1     ));
         }

--- a/src/names.cpp
+++ b/src/names.cpp
@@ -389,7 +389,7 @@ bool ExistClub(int a_index)
 {
     return     (a_index > 0)
             && (static_cast<size_t>(a_index) < svClubNames.size())
-            && !svClubNames[a_index].empty();
+            && !svClubNames[a_index].IsEmpty();
 }   // ExistClub()
 
 bool ExistClub(const wxString& a_clubName, int* a_pIndex)
@@ -420,7 +420,7 @@ int GetFreeClubIndex()
 
 UINT DetermineClubIndex(const wxString& a_club)
 {
-    if (a_club.empty()) return 0;
+    if (a_club.IsEmpty()) return 0;
 
     UINT ii = 1;
     for (; ii <= suNrOfClubs; ++ii)

--- a/src/orgInterface.cpp
+++ b/src/orgInterface.cpp
@@ -569,7 +569,7 @@ namespace  org
         for (auto buf = tf.GetFirstLine(); !tf.Eof(); buf = tf.GetNextLine())
         {
             buf.Trim(TRIM_LEFT);buf.Trim(TRIM_RIGHT);    // remove spaces in front and back
-            if (buf.empty() || buf[0]==';')
+            if (buf.IsEmpty() || buf[0]==';')
                 continue;                                // ignore empty lines and comment lines
 
             UINT id;
@@ -605,7 +605,7 @@ namespace  org
 
         for ( UINT ii = 1; ii < a_clubNames.size(); ++ii)
         {
-            if ( !a_clubNames[ii].empty() )
+            if ( !a_clubNames[ii].IsEmpty() )
             {
                 wxString tmp = FMT("%3u, %s", ii, a_clubNames[ii]);
                 tf.AddLine(tmp);
@@ -932,7 +932,7 @@ namespace  org
             // <score.2> <glbpair> <bonus.2> S<games> <pairname>
             // +100.00    1        [-99.99 ] s16   xxx - xxx
             str.Trim(TRIM_LEFT); str.Trim(TRIM_RIGHT);
-            if ( str.empty() || str[0] == ';' ) continue;
+            if ( str.IsEmpty() || str[0] == ';' ) continue;
 
             bool    bLineError  = false;
             int     count;
@@ -1034,7 +1034,7 @@ namespace  org
             //;<correctie><type> <sessiepaarnr> <extra.1> <max extra> <paarnaam>
             //    +3        %      28              0           0      paar 28
             str.Trim(TRIM_LEFT); str.Trim(TRIM_RIGHT);
-            if ( str.empty() || str[0] == ';' ) continue;
+            if ( str.IsEmpty() || str[0] == ';' ) continue;
 
             UINT    charCount;
             UINT    sessionPairnr;

--- a/src/orgInterface.cpp
+++ b/src/orgInterface.cpp
@@ -657,10 +657,54 @@ namespace  org
         return true;
     }   // SessionNamesRead()
 
+
+#ifdef _WIN32           // for vs 32/64bit we need 1 byte packing to read/write 'old' data
+    #pragma pack(1)
+#endif
+
+        /*
+        Layout of score-file:
+        Scores[cfg::MAX_PAIRS/2+1]  -> entry[0] = DESCRIPTION, rest is zero
+        N*Scores[x]                 -> N=games with data, entry[0]=SetCount, rest: Scores[nrOfSets] of GameSetData
+        */
+
+    struct GameSetDataOrg
+    {
+        UINT8   pairNS;         // database used 8bit variables to preserve space (640Kb in DOS!)
+        UINT8   pairEW;         // so we were limited by this to 255 pairs
+        INT16   scoreNS;        // Schemadata used 8bit signed pairs (+ -> NS, - -> EW)
+        INT16   scoreEW;        // so pairs were limited to 127
+    };
+
+    struct DESCRIPTION
+    {
+        INT16   dataType;
+        UINT16  nrOfGamesWithData;
+        UINT16  restSize; //rest of data AFTER row 0 (== Scores[cfg::MAX_PAIRS/2+1]  )
+    };
+
+    struct SetCount
+    {
+        UINT8   dummy[2];
+        UINT8   nrOfSets;
+    };
+
+    union Scores
+    {
+        GameSetDataOrg  setData;
+        DESCRIPTION     description;
+        SetCount        setCount;
+    };
+
+#ifdef _WIN32
+    #pragma pack()
+#endif
+
+
     static constexpr int    CURRENT_TYPE = 1;        // version of datastorage
     bool ScoresRead(vvScoreData& a_scoreData, UINT /*a_session*/)
     {
-        score::Scores      gamesetdata[MAX_PAIRS3/2+1];
+        Scores      gamesetdata[MAX_PAIRS3/2+1];
         wxString    scoreFile   = _ConstructFilename( cfg::EXT_SESSION_SCORE );
         bool        bError      = false;
         wxString    errorMsg    = _(": readerror");
@@ -695,7 +739,12 @@ namespace  org
                         scores.clear();
                         for (UINT sets = 1; sets <= nrOfSets; ++sets)
                         {
-                            scores.push_back(gamesetdata[sets].setData);
+                            score::GameSetData newData;    // old to new
+                            newData.pairNS  = gamesetdata[sets].setData.pairNS;
+                            newData.pairEW  = gamesetdata[sets].setData.pairEW;
+                            newData.scoreNS = gamesetdata[sets].setData.scoreNS;
+                            newData.scoreEW = gamesetdata[sets].setData.scoreEW;
+                            scores.push_back(newData);
                         }
                         a_scoreData[game] = scores;
                     }
@@ -730,14 +779,14 @@ namespace  org
             return false;
         }
 
-        score::Scores      gamesetdata[MAX_PAIRS3/2+1] = {0};
+        Scores      gamesetdata[MAX_PAIRS3/2+1] = {0};
         bool        bError      = false;
         UINT        restSize    = 0;
         UINT        nrOfGames   = score::GetNumberOfGames(&a_scoreData);
 
         for (UINT game = 1; game <= nrOfGames; ++game)
             restSize += 1+a_scoreData[game].size();
-        restSize *= sizeof(score::Scores);
+        restSize *= sizeof(Scores);
         gamesetdata[0].description.dataType             = CURRENT_TYPE;
         gamesetdata[0].description.nrOfGamesWithData    = nrOfGames;
         gamesetdata[0].description.restSize             = restSize;
@@ -757,7 +806,12 @@ namespace  org
 
             for (UINT set = 1; set <= nrOfSets; ++set)
             {
-                gamesetdata[set].setData = gameData[set-1];
+                GameSetDataOrg oldData;    // new to old, ignoring possible contracts
+                oldData.pairNS  = gameData[set-1].pairNS;
+                oldData.pairEW  = gameData[set-1].pairEW;
+                oldData.scoreNS = gameData[set-1].scoreNS;
+                oldData.scoreEW = gameData[set-1].scoreEW;
+                gamesetdata[set].setData = oldData;
             }
             if (fwrite(&gamesetdata[1], sizeof(gamesetdata[0]), nrOfSets, fp) != nrOfSets)  // write set-data
             {    bError = true; goto error; }

--- a/src/printer.cpp
+++ b/src/printer.cpp
@@ -565,7 +565,7 @@ bool MyLinePrinter::PrinterOpen()
         return true;    // printer already opened.
     }
 
-    if (m_sPrinterName.empty())
+    if (m_sPrinterName.IsEmpty())
     {
         if (!SelectPrinter())
         {

--- a/src/score.h
+++ b/src/score.h
@@ -16,51 +16,18 @@ namespace score
     #define SCORE_NP        -2      /* N(ot)P(layed) score: game not played, perhaps no time... */
     #define SCORE_IGNORE    1000000L    /* this value in endcorrrections: just ignore if only bonus present */
     #define SCORE_NO_TOTAL  2000000L    /* this value in endcorrrections: sessionScore NOT added to total score*/
-    #ifdef _WIN32           // for vs 32/64bit we need 1 byte packing to read/write 'old' data
-    #pragma pack(1)
-    #endif
-
-    /*
-    Layout of score-file:
-    Scores[cfg::MAX_PAIRS/2+1]  -> entry[0] = DESCRIPTION, rest is zero
-    N*Scores[x]                 -> N=games with data, entry[0]=SetCount, rest: Scores[nrOfSets] of GameSetData
-    */
 
     struct GameSetData
     {
-        UINT8   pairNS;         // NB should be changed to UINT, but compatability with 'old' databases is compromised!
-        UINT8   pairEW;
-        INT16   scoreNS;
-        INT16   scoreEW;
+        UINT   pairNS;
+        UINT   pairEW;
+        int    scoreNS;
+        int    scoreEW;
         bool operator < (const GameSetData &rhs) const
         {   /* sorting on NS */ return pairNS < rhs.pairNS; }
         bool operator == (const GameSetData &rhs) const
         {return rhs.pairNS == pairNS && rhs.pairEW == pairEW && rhs.scoreNS == scoreNS && rhs.scoreEW == scoreEW;}
     };
-
-    struct DESCRIPTION
-    {
-        INT16   dataType;
-        UINT16  nrOfGamesWithData;
-        UINT16  restSize; //rest of data AFTER row 0 (== Scores[cfg::MAX_PAIRS/2+1]  )
-    };
-
-    struct SetCount
-    {
-        UINT8   dummy[2];
-        UINT8   nrOfSets;
-    };
-
-    union Scores
-    {
-        GameSetData setData;
-        DESCRIPTION description;
-        SetCount    setCount;
-    };
-
-    #ifdef _WIN32
-    #pragma pack()
-    #endif
 
     bool WriteSessionRank           (const std::vector<unsigned int>& a_vSessionRank);
     bool WriteTotalRank             (const std::vector<unsigned int>& a_vTotalRank);

--- a/src/score.h
+++ b/src/score.h
@@ -19,10 +19,12 @@ namespace score
 
     struct GameSetData
     {
-        UINT   pairNS;
-        UINT   pairEW;
-        int    scoreNS;
-        int    scoreEW;
+        UINT        pairNS;
+        UINT        pairEW;
+        int         scoreNS;
+        int         scoreEW;
+        wxString    contractNS;
+        wxString    contractEW;
         bool operator < (const GameSetData &rhs) const
         {   /* sorting on NS */ return pairNS < rhs.pairNS; }
         bool operator == (const GameSetData &rhs) const
@@ -46,24 +48,58 @@ namespace score
         , ScoreInvalid  // incorrect score
         , ScoreSpecial  // possible score, but highly unexpected like 6 down
     };
-    void                ReadScoresFromDisk  ();
-    void                WriteScoresToDisk   ();
-    const vvScoreData*  GetScoreData        ();                     // get a ptr to the current scores
-    void                SetScoreData        (const vvScoreData&);   // update the scores (write to disk)
-    UINT                GetNumberOfGames    (const vvScoreData* a_scoreData = nullptr);                     // highest gamenr that is played in a session
-    bool                IsReal              (int score);            // checks if score is real (not adjusted)
-    bool                IsProcent           (int score);            // checks if its a '%' score
-    wxString            ScoreToString       (int score);            // get string representation of score
-    int                 ScoreFromString     (const wxString& score);// convert string to (possible) score
-    bool                IsVulnerable        (UINT game, bool bNS);  // checks for vulnerability
-    char                VulnerableChar      (UINT game, bool bNS);  // returns '*' if vulnerable else ' '
-    ScoreValidation     IsScoreValid        (int score, UINT game, bool bNS);   // checks if a score is valid
-    int                 Score2Real          (int score);            // make adjusted real score into real score
+    void                ReadScoresFromDisk();
+    void                WriteScoresToDisk();
+    const vvScoreData*  GetScoreData();                     // get a ptr to the current scores
+    void                SetScoreData(const vvScoreData&);   // update the scores (write to disk)
+    UINT                GetNumberOfGames(const vvScoreData* a_scoreData = nullptr);                     // highest gamenr that is played in a session
+    bool                IsReal(int score);            // checks if score is real (not adjusted)
+    bool                IsProcent(int score);            // checks if its a '%' score
+    wxString            ScoreToString(int score);            // get string representation of score
+    int                 ScoreFromString(const wxString& score);// convert string to (possible) score
+    bool                IsVulnerable(UINT game, bool bNS);  // checks for vulnerability
+    char                VulnerableChar(UINT game, bool bNS);  // returns '*' if vulnerable else ' '
+    ScoreValidation     IsScoreValid(int score, UINT game, bool bNS);   // checks if a score is valid
+    int                 Score2Real(int score);            // make adjusted real score into real score
     int                 Procentscore2Procent(int score);            // convert aribitrairy score to 0<=value<=100
     UINT                GetNumberOfGamesPlayedByGlobalPair(UINT globalPairnr);
-    bool                ExistGameData       ();                     // true, if there is atleast one score entered
-    bool                AdjustPairNrs       (UINT fromPair, int delta); // adjust all pairnrs in the scoredata starting from 'frompair' with 'delta', return true if one or more changes
+    bool                ExistGameData();                     // true, if there is atleast one score entered
+    bool                AdjustPairNrs(UINT fromPair, int delta); // adjust all pairnrs in the scoredata starting from 'frompair' with 'delta', return true if one or more changes
     bool                DeleteScoresFromPair(UINT sessionPair);     // delete all scores for 'pair', return true if anything deleted
 
-}      // end of namespace score
+    // next some enums and methods to handle contracts in text
+    enum PlayType :int
+    {
+          PlayTypeFirst   = 0
+        , PtClubsDiamonds = PlayTypeFirst
+        , PtHeartsSpades  = 1
+        , PtNoTrump       = 2
+        , PlayTypeLast    = PtNoTrump
+    };
+
+    enum CardId :int
+    {
+          CardIdFirst   = 0
+        , CiClubs       = CardIdFirst
+        , CiDiamonds    = 1
+        , CiHearts      = 2
+        , CiSpades      = 3
+        , CiNoTrump     = 4
+        , CardIdLast    = CiNoTrump
+    };
+
+    /*
+    *  Get the score for the contract in 'input': "-n[*[*]]"  or "n'SUITE'[[+|-]n][*[*]]"
+    *  return value:
+    *    0  = error in calculation: not all params are consistent
+    *   -1  = malformed contract, show usage
+    *  rest = correct score
+    */
+    int                 GetContractScoreFromString(const wxString& input, bool bVulnerable, wxString& result);
+    wxString            GetDoubledTypeName        (int         type           );
+    wxString            GetPlayTypeName           (PlayType    type           );
+    wxString            GetCardName               (CardId      id             );    // name of the suit
+    void                InitTexts4Translation     (bool        bForce = false );    // init static texts for translation
+
+} // end of namespace score
 #endif

--- a/src/scoreEntry.h
+++ b/src/scoreEntry.h
@@ -43,6 +43,7 @@ private:
     void        OnSelectRound       (wxCommandEvent&);
     void        OnSelectGame        (wxCommandEvent&);
     void        OnSwitchNsEw        (wxCommandEvent&);
+    void        OnCheckboxContract  (wxCommandEvent&);
 
     MyGrid*     m_theGrid;
     wxRadioBox* m_pRadioBoxSlipGame;// select input order based on slip (sets) or game number
@@ -59,6 +60,7 @@ private:
     UINT        m_uActiveGame;      // the choosen game nr
     wxBoxSizer* m_pSizerAllChoices; // for choices: slip/ns/round/game
     bool        m_bCancelInProgress;// true, if cancel is wanted
+    wxCheckBox* m_pCheckboxContract;// if set, columns 'COL_CONTRACT_NS'and 'COL_CONTRACT_EW' are shown
 
     enum
     {
@@ -66,6 +68,8 @@ private:
         , COL_GAME = COL_ZERO               // game nr
         , COL_NS                            // NS session pair nr
         , COL_EW                            // EW session pair nr
+        , COL_CONTRACT_NS                   // contract entry for NS
+        , COL_CONTRACT_EW                   // contract entry for EW
         , COL_SCORE_NS                      // score NS
         , COL_SCORE_EW                      // score EW (only if adjusted score)
         , COL_NAME_NS                       // pairname NS

--- a/src/setupNewMatch.cpp
+++ b/src/setupNewMatch.cpp
@@ -102,7 +102,7 @@ void SetupNewMatch::UpdateSelection()
     wxString extension  = io::DatabaseTypeGet() == io::DB_ORG ? ".ini" : ".db";
     wxArrayString choices;
     wxString file = wxFindFirstFile(path + "/*" + extension);
-    while ( !file.empty() )
+    while ( !file.IsEmpty() )
     {
         file = file.AfterLast('/').AfterLast('\\'); // remove path
         if (file != cfg::GetBareMainIni())


### PR DESCRIPTION
- stupid typo in IsInRange()
- decoupled old/global gameinfo
- small texts update
- consequent use of wxString::IsEmpty() i.s.o wxString::empty()
- changed some wxStatictext to wxGenericStaticText to prevent clipping problems
- solved problem when .db was on a non-existing/non-writable location
- now current programversion is always updated in the datafiles
- entry of scores can now also be done by contract i.s.o pure score-data
- updated wxWidgets to V3.2.7 (no changes compared to V3.2.6)
