### PR TITLE
changes leading to V10.8.0

### DIFF
--- a/BridgeWx.props
+++ b/BridgeWx.props
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ImportGroup Label="PropertySheets" />
+  <PropertyGroup Label="UserMacros">
+    <!--  You can use environment variables for the following item(s), or use this property sheet -->
+    <wxwin>D:\wxWidgets_3.3.0</wxwin>  <!--  the base directory of the used wxWidgets version -->
+  </PropertyGroup>
+  <PropertyGroup />
+  <ItemDefinitionGroup />
+</Project>

--- a/BridgeWx.vcxproj
+++ b/BridgeWx.vcxproj
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <WX_VERSION Condition=" '$(WX_VERSION)' == '' ">33</WX_VERSION>
-  </PropertyGroup>
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -43,6 +40,8 @@
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="BridgeWx.props" Condition="$(wxwin)==''" />
+  <Import Project="$(wxwin)\build\msw\wx_setup.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DLL Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <PlatformToolset>v142</PlatformToolset>
@@ -391,7 +390,7 @@
       <AdditionalIncludeDirectories>$(WXWIN)\lib\vc_x64_lib\mswud;$(WXWIN)\include;.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>wxmsw$(WX_VERSION)ud_core.lib;wxbase$(WX_VERSION)ud.lib;wxwebpd.lib;wxtiffd.lib;wxjpegd.lib;wxpngd.lib;wxzlibd.lib;wxregexud.lib;wxexpatd.lib;kernel32.lib;user32.lib;gdi32.lib;comdlg32.lib;winspool.lib;winmm.lib;shell32.lib;shlwapi.lib;comctl32.lib;ole32.lib;oleaut32.lib;uuid.lib;rpcrt4.lib;advapi32.lib;version.lib;ws2_32.lib;wininet.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>wxmsw$(wxShortVersionString)ud_core.lib;wxbase$(wxShortVersionString)ud.lib;wxwebpd.lib;wxtiffd.lib;wxjpegd.lib;wxpngd.lib;wxzlibd.lib;wxregexud.lib;wxexpatd.lib;kernel32.lib;user32.lib;gdi32.lib;comdlg32.lib;winspool.lib;winmm.lib;shell32.lib;shlwapi.lib;comctl32.lib;ole32.lib;oleaut32.lib;uuid.lib;rpcrt4.lib;advapi32.lib;version.lib;ws2_32.lib;wininet.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>vc_x64_mswud\$(TargetName).exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <AdditionalLibraryDirectories>$(WXWIN)\lib\vc_x64_lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
@@ -440,7 +439,7 @@
       <AdditionalIncludeDirectories>$(WXWIN)\lib\vc_x64_lib\mswu;$(WXWIN)\include;.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>wxmsw$(WX_VERSION)u_core.lib;wxbase$(WX_VERSION)u.lib;wxwebp.lib;wxtiff.lib;wxjpeg.lib;wxpng.lib;wxzlib.lib;wxregexu.lib;wxexpat.lib;kernel32.lib;user32.lib;gdi32.lib;comdlg32.lib;winspool.lib;winmm.lib;shell32.lib;shlwapi.lib;comctl32.lib;ole32.lib;oleaut32.lib;uuid.lib;rpcrt4.lib;advapi32.lib;version.lib;ws2_32.lib;wininet.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>wxmsw$(wxShortVersionString)u_core.lib;wxbase$(wxShortVersionString)u.lib;wxwebp.lib;wxtiff.lib;wxjpeg.lib;wxpng.lib;wxzlib.lib;wxregexu.lib;wxexpat.lib;kernel32.lib;user32.lib;gdi32.lib;comdlg32.lib;winspool.lib;winmm.lib;shell32.lib;shlwapi.lib;comctl32.lib;ole32.lib;oleaut32.lib;uuid.lib;rpcrt4.lib;advapi32.lib;version.lib;ws2_32.lib;wininet.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>vc_x64_mswu\$(TargetName).exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <AdditionalLibraryDirectories>$(WXWIN)\lib\vc_x64_lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
@@ -492,7 +491,7 @@
       <AdditionalIncludeDirectories>$(WXWIN)\lib\vc_x64_dll\mswud;$(WXWIN)\include;.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>wxmsw$(WX_VERSION)ud_core.lib;wxbase$(WX_VERSION)ud.lib;wxtiffd.lib;wxjpegd.lib;wxpngd.lib;wxzlibd.lib;wxregexud.lib;wxexpatd.lib;kernel32.lib;user32.lib;gdi32.lib;comdlg32.lib;winspool.lib;winmm.lib;shell32.lib;shlwapi.lib;comctl32.lib;ole32.lib;oleaut32.lib;uuid.lib;rpcrt4.lib;advapi32.lib;version.lib;ws2_32.lib;wininet.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>wxmsw$(wxShortVersionString)ud_core.lib;wxbase$(wxShortVersionString)ud.lib;wxtiffd.lib;wxjpegd.lib;wxpngd.lib;wxzlibd.lib;wxregexud.lib;wxexpatd.lib;kernel32.lib;user32.lib;gdi32.lib;comdlg32.lib;winspool.lib;winmm.lib;shell32.lib;shlwapi.lib;comctl32.lib;ole32.lib;oleaut32.lib;uuid.lib;rpcrt4.lib;advapi32.lib;version.lib;ws2_32.lib;wininet.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>vc_x64_mswuddll\$(TargetName).exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <AdditionalLibraryDirectories>$(WXWIN)\lib\vc_x64_dll;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
@@ -540,7 +539,7 @@
       <AdditionalIncludeDirectories>$(WXWIN)\lib\vc_x64_dll\mswu;$(WXWIN)\include;.;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>wxmsw$(WX_VERSION)u_core.lib;wxbase$(WX_VERSION)u.lib;wxtiff.lib;wxjpeg.lib;wxpng.lib;wxzlib.lib;wxregexu.lib;wxexpat.lib;kernel32.lib;user32.lib;gdi32.lib;comdlg32.lib;winspool.lib;winmm.lib;shell32.lib;shlwapi.lib;comctl32.lib;ole32.lib;oleaut32.lib;uuid.lib;rpcrt4.lib;advapi32.lib;version.lib;ws2_32.lib;wininet.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>wxmsw$(wxShortVersionString)u_core.lib;wxbase$(wxShortVersionString)u.lib;wxtiff.lib;wxjpeg.lib;wxpng.lib;wxzlib.lib;wxregexu.lib;wxexpat.lib;kernel32.lib;user32.lib;gdi32.lib;comdlg32.lib;winspool.lib;winmm.lib;shell32.lib;shlwapi.lib;comctl32.lib;ole32.lib;oleaut32.lib;uuid.lib;rpcrt4.lib;advapi32.lib;version.lib;ws2_32.lib;wininet.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OutputFile>vc_x64_mswudll\$(TargetName).exe</OutputFile>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <AdditionalLibraryDirectories>$(WXWIN)\lib\vc_x64_dll;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>

--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ Remark: English is buildin, so for this language you don't need to do anything
     - set wxwin=d:\wxWidgets_3.3.0  ( == \<wxBase\> )
     - set wx_version=33             ( for V3.3.* (default) and '32' for V3.2.*)
  - start BridgeWx.sln (from the base folder where the repo is located)
+    - from version V10.8.0 onwards, you can also use the BridgeWx.props file i.s.o the environment variable(s)
+       - adjust the value(s) in it so they match your situation
+       - the environment has priority above the .props file
 
  - initially to have the Dutch language available for the locally compiled executable:
      - create the folder(s) for the Dutch language (automaticaly done when building in VS):

--- a/files_main.txt
+++ b/files_main.txt
@@ -7,6 +7,7 @@ delCompareLogs.bat
 BridgeWx.sln
 BridgeWx.vcxproj
 BridgeWx.vcxproj.filters
+BridgeWx.props
 makeSource.bat
 prebuild.bat
 release\makeRelease.bat

--- a/prebuild.bat
+++ b/prebuild.bat
@@ -11,7 +11,7 @@ echo PreBuild.bat: Debug/Release = '%~1', outdir = '%~2', wxwin = '%~3'
 SETLOCAL EnableExtensions
 
 if not [%3] == [] if exist "%~3\locale" goto OkWxwin
-  .\tools\msgbox.exe ERROR! "variable 'wxwin' ('%~3') is empty or does not exist" "" "its needed for building!" "use environment variables or BridgeWx.props"
+  .\tools\msgbox.exe ERROR! "environment var wxwin '%~3' is empty or does not exist" "" "its needed for building!"
   exit /B 1
 :OkWxwin
 
@@ -20,7 +20,6 @@ set p1=%~1
 set p2=%~2
 set p3=%~3
 
-set builddateLanguage=en-UK
 set msgbox=.\tools\msgbox.exe
 set language=nl
 call :setupLanguage
@@ -67,7 +66,7 @@ goto builddate
 if /I [%p1%] == [Debug]     goto DoneBuildDate
 if /I [%p1%] == [DLL Debug] goto DoneBuildDate
   echo creating .\src\builddate.h
-  .\tools\builddate.exe %builddateLanguage% > .\src\buildDate.h
+  .\tools\builddate.exe > .\src\buildDate.h
 :DoneBuildDate
 
 set       p1=

--- a/prebuild.bat
+++ b/prebuild.bat
@@ -11,7 +11,7 @@ echo PreBuild.bat: Debug/Release = '%~1', outdir = '%~2', wxwin = '%~3'
 SETLOCAL EnableExtensions
 
 if not [%3] == [] if exist "%~3\locale" goto OkWxwin
-  .\tools\msgbox.exe ERROR! "environment var wxwin '%~3' is empty or does not exist" "" "its needed for building!"
+  .\tools\msgbox.exe ERROR! "variable 'wxwin' ('%~3') is empty or does not exist" "" "its needed for building!" "use environment variables or BridgeWx.props"
   exit /B 1
 :OkWxwin
 
@@ -20,6 +20,7 @@ set p1=%~1
 set p2=%~2
 set p3=%~3
 
+set builddateLanguage=en-GB
 set msgbox=.\tools\msgbox.exe
 set language=nl
 call :setupLanguage
@@ -66,7 +67,7 @@ goto builddate
 if /I [%p1%] == [Debug]     goto DoneBuildDate
 if /I [%p1%] == [DLL Debug] goto DoneBuildDate
   echo creating .\src\builddate.h
-  .\tools\builddate.exe > .\src\buildDate.h
+  .\tools\builddate.exe %builddateLanguage% > .\src\buildDate.h
 :DoneBuildDate
 
 set       p1=

--- a/prebuild.bat
+++ b/prebuild.bat
@@ -11,7 +11,7 @@ echo PreBuild.bat: Debug/Release = '%~1', outdir = '%~2', wxwin = '%~3'
 SETLOCAL EnableExtensions
 
 if not [%3] == [] if exist "%~3\locale" goto OkWxwin
-  .\tools\msgbox.exe ERROR! "environment var wxwin '%~3' is empty or does not exist" "" "its needed for building!"
+  .\tools\msgbox.exe ERROR! "variable 'wxwin' ('%~3') is empty or does not exist" "" "its needed for building!" "use environment variables or BridgeWx.props"
   exit /B 1
 :OkWxwin
 
@@ -20,6 +20,7 @@ set p1=%~1
 set p2=%~2
 set p3=%~3
 
+set builddateLanguage=en-UK
 set msgbox=.\tools\msgbox.exe
 set language=nl
 call :setupLanguage
@@ -66,7 +67,7 @@ goto builddate
 if /I [%p1%] == [Debug]     goto DoneBuildDate
 if /I [%p1%] == [DLL Debug] goto DoneBuildDate
   echo creating .\src\builddate.h
-  .\tools\builddate.exe > .\src\buildDate.h
+  .\tools\builddate.exe %builddateLanguage% > .\src\buildDate.h
 :DoneBuildDate
 
 set       p1=

--- a/release/releasenotes.md
+++ b/release/releasenotes.md
@@ -1,4 +1,14 @@
 # Releasenotes
+#V10.8.0  ....
+ - disabled v3.3.0 feature to show highlighted grid columnlabel on activating a cell
+ - when producing builddate.h, 'prebuild.bat' now defaults to 'en_UK' locales for date and time
+ - use ./build/msw/wx_setup.props to get the version-dependend names of some wx libraries
+ - added 'BridgeWx.props' to set needed variable(s): wxwin (base of wxWidgets version)
+   - remark: if 'wxwin'is set in the environment, the BridgeWx.props file is not loaded
+ - changed disabled feature: 
+   - bad side effect: columnheaders got a much larger margin, so many texts did not fit anymore
+   - new implementation has nice side effect of having sort-icons available in the column headers
+
 #V10.7.0  Monday June 9, 2025
  - easier translation (more)
  - wxCombobox sometimes truncates content (old problem again)

--- a/src/assignNames.cpp
+++ b/src/assignNames.cpp
@@ -38,6 +38,7 @@ AssignNames::AssignNames(wxWindow* a_pParent, UINT a_pageId) :Baseframe(a_pParen
     m_theGrid->SetColSize(COL_RANK_TOTAL_PREV      , SIZE_ID_PIX      ); m_theGrid->SetColLabelValue(COL_RANK_TOTAL_PREV    , _("rank"    ));   // TRANSLATORS: 'S' is first char of Session
     m_theGrid->SetColSize(COL_RANK_SESSION_PREV    , SIZE_ID_PIX      ); m_theGrid->SetColLabelValue(COL_RANK_SESSION_PREV  , _("rank S-1"));
 
+#ifdef MY_GRIDSORT
     std::vector<MyGrid::SortMethod> methods;
     methods.push_back(MyGrid::SORT_STRING);
     methods.push_back(MyGrid::SORT_SESSIONNAME);
@@ -45,7 +46,8 @@ AssignNames::AssignNames(wxWindow* a_pParent, UINT a_pageId) :Baseframe(a_pParen
     methods.push_back(MyGrid::SORT_INTNUMBER);
     methods.push_back(MyGrid::SORT_INTNUMBER);
     m_theGrid->SetSortMethod(methods);          // set sort hints: without this, plain string compare is done
-
+    m_theGrid->SetSortEnable(true);
+#endif
     auto pStaticText    = new wxStaticText(this, wxID_ANY, _("Assign pairnames on base of:  "));
     auto pButtonOrg     = new wxButton    (this, wxID_ANY, _("Original nr"));
     m_pButtonRankTotal  = new wxButton    (this, wxID_ANY, _("Rank total" ));

--- a/src/mygrid.cpp
+++ b/src/mygrid.cpp
@@ -19,6 +19,7 @@ MyGrid::MyGrid(Baseframe* a_pParent, const wxString& a_ahkLabel) : wxGrid(a_pPar
     if (a_pParent) SetLabelFont(a_pParent->GetFont());  // just incase the parent font is NOT standard
     SetColLabelAlignment(wxALIGN_LEFT, wxALIGN_CENTER);
     SetTabBehaviour(Tab_Wrap);  // wrap to next/previous row: till end/begin
+    UseNativeColHeader(true);   // V3.3.*: disables highlight of columnheader when a cell is selected
     Bind(wxEVT_GRID_CELL_CHANGING,    &MyGrid::OnCellChanging,   this, wxID_ANY);   // check for changes and signal owner
     Bind(wxEVT_GRID_LABEL_LEFT_CLICK, &MyGrid::OnLeftClickLabel, this, wxID_ANY);
 

--- a/src/mygrid.cpp
+++ b/src/mygrid.cpp
@@ -19,7 +19,8 @@ MyGrid::MyGrid(Baseframe* a_pParent, const wxString& a_ahkLabel) : wxGrid(a_pPar
     if (a_pParent) SetLabelFont(a_pParent->GetFont());  // just incase the parent font is NOT standard
     SetColLabelAlignment(wxALIGN_LEFT, wxALIGN_CENTER);
     SetTabBehaviour(Tab_Wrap);  // wrap to next/previous row: till end/begin
-    UseNativeColHeader(true);   // V3.3.*: disables highlight of columnheader when a cell is selected
+//    UseNativeColHeader(true);   // V3.3.*: disables highlight of columnheader when a cell is selected
+    SetUseNativeColLabels(true);    // V3.3.*: disables highlight of columnheader when a cell is selected
     Bind(wxEVT_GRID_CELL_CHANGING,    &MyGrid::OnCellChanging,   this, wxID_ANY);   // check for changes and signal owner
     Bind(wxEVT_GRID_LABEL_LEFT_CLICK, &MyGrid::OnLeftClickLabel, this, wxID_ANY);
 
@@ -27,7 +28,7 @@ MyGrid::MyGrid(Baseframe* a_pParent, const wxString& a_ahkLabel) : wxGrid(a_pPar
     Bind(wxEVT_GRID_COL_SORT,         &MyGrid::OnSortColumn    , this, wxID_ANY);   // sorting
     m_sortedCol     = wxNOT_FOUND;
     m_sortType      = SORT_NONE;
-    m_bEnableSort   = true;
+    m_bEnableSort   = false;
     CallAfter(&MyGrid::BindLate);
     //    SetUseNativeColLabels(true);    // for sorting indication
 #endif
@@ -172,8 +173,8 @@ void MyGrid::OnLeftClickLabel(wxGridEvent& a_event)
 {   // eat it, if its a column label: no whole column selection
     int col = a_event.GetCol();
     LogMessage(_("MyGrid::OnLeftClickLabel(column: %i)"), col);
-    if ( col == wxNOT_FOUND)
-        a_event.Skip(); // passtrough if its not a column header
+//    if ( col == wxNOT_FOUND)    // left-edge -> select all
+//        a_event.Skip(); // passtrough if its not a column header
 }   // OnLeftClickLabel()
 
 const MyGrid::GridInfo& MyGrid::GetGridInfo()
@@ -281,7 +282,7 @@ bool MyGrid::AppendRows(int a_numRows, bool a_updateLabels)
     return wxGrid::AppendRows(a_numRows, a_updateLabels);
 }   // AppendRows()
 
-[[maybe_unused]] bool MyGrid::GridSortEnable(bool a_bEnable)
+bool MyGrid::SetSortEnable(bool a_bEnable)
 {
     if ( !a_bEnable && (m_sortType != SORT_NONE) )
     {   // undo sorting
@@ -294,7 +295,7 @@ bool MyGrid::AppendRows(int a_numRows, bool a_updateLabels)
     m_bEnableSort = a_bEnable;
 
     return bOldSort;
-}   // GridSortEnable()
+}   // SetSortEnable()
 
 void MyGrid::SortOnLeftClickLabel(wxGridEvent& a_event)
 {
@@ -376,8 +377,6 @@ bool MyCompare(const wxString& s1, const wxString& s2, MyGrid::SortMethod a_sort
 
 void MyGrid::OnSortColumn(wxGridEvent& a_event)
 {
-    LogMessage(_("MyGrid::OnSortColumn(column: %i)"), a_event.GetCol());
-
     int rows    = GetNumberRows();
     int sortCol = a_event.GetCol();
 
@@ -386,6 +385,8 @@ void MyGrid::OnSortColumn(wxGridEvent& a_event)
         a_event.Skip(); // we don't handle this one
         return;
     }
+
+    LogMessage(_("MyGrid::OnSortColumn(column: %i)"), a_event.GetCol());
 
     int cols = GetNumberCols();
     std::vector< std::vector<wxString> > data;
@@ -411,6 +412,27 @@ void MyGrid::OnSortColumn(wxGridEvent& a_event)
         m_sortedCol= sortCol;
         m_sortType = next[0];
     }
+
+    // We get this event FIRST (on purpose!), but when finished here, the event will also be processed
+    // by the system and will result in setting the 'wxGrid::m_sortCol' from 'wxNOT_FOUND' to 'sortCol' again
+    // and that will result in getting a 'sort_up' icon again :-(
+    // So be sure that we are the LAST person processing...
+    CallAfter([this]
+                {
+                    switch (m_sortType)
+                    {   // update the sort icon
+                        case SORT_UP:
+                            SetSortingColumn (m_sortedCol, true);
+                            break;
+                        case SORT_DOWN:
+                            SetSortingColumn (m_sortedCol, false);
+                            break;
+                        default:
+                            UnsetSortingColumn();
+                            break;
+                    }
+                }
+        );
 
     m_sortedRows.resize(rows);
     std::iota (m_sortedRows.begin(), m_sortedRows.end(), 0); // Fill with 0, 1, ..., i.e. non-sorted! 0->0, 1->1 etc

--- a/src/mygrid.h
+++ b/src/mygrid.h
@@ -23,6 +23,7 @@ public:
     void        SetMaxChars (int row, int col, const wxString& sMaxCharsInColumn);  // setmax nr of chars in a (text)column
     void        PrintGrid   (const wxString& title, UINT nrOfColumnsToPrint, UINT notEmptyfrom = MaxRow);   //print grid content upto <x> columns, if columns > <y> not empty 
 
+#ifdef MY_GRIDSORT
     enum SortMethod
     {
           SORT_DISABLED = 0             // no sorting wanted....
@@ -34,20 +35,19 @@ public:
     };
     void        SetSortMethod           (const std::vector<MyGrid::SortMethod>& sortTypes);
 
-#ifdef MY_GRIDSORT
     // catch grid functions to translate rows->intern->extern
     // some helper funcions
     void        SetCellValue            ( int row, int col, const wxString& s );
     wxString    GetCellValue            ( int row, int col ) const;
-    int         GridRowToExtern         ( int row );            //if sorting: translate internal row to external row nr
+    int         GridRowToExtern         ( int row );            // if sorting: translate internal row to external row nr
     int         GridRowToIntern         ( int row ) const;      // if sorting: translate external row to internal row nr
     bool        AppendRows              ( int numRows = 1, bool updateLabels = true);    // if sorting, extend the sort-array
-    bool        GridSortEnable          ( bool enable = true);  // enable/disable row-sorting
+    bool        SetSortEnable           ( bool enable = true);  // enable/disable row-sorting, return previous setting
     void        SetRowBackground        ( int row, const wxColour& colour); //sets the background colour for a whole row
 #endif
 
     struct GridInfo
-    {   // for autotest mouse positions
+    {   // for autotest mouse positions/window labels
         wxWindow*   pGridWindow = nullptr;
         int         rowLabelSize= -1;
         int         colLabelSize= -1;
@@ -72,13 +72,13 @@ private:
     void OnSortColumn           (wxGridEvent& event);   // sorting, based on column
     void SortOnLeftClickLabel   (wxGridEvent& event);   // left click column header
     void SortOnCellChanging     (wxGridEvent& event);   // end of editing: old and new data returned, if changed call Baseframe:: OnCellChanging()
-    void SortOnSelectCell       (wxGridEvent& event);    // set start position for search to current selection
+    void SortOnSelectCell       (wxGridEvent& event);   // set start position for search to current selection
 
     void BindLate();                                // be sure that your are latest binder to get first called on events!
     std::vector<int>    m_sortedRows;               // [n] -> original row 'n' is now shown at row [n]
-    SORT_DIRECTION      m_sortType;
+    SORT_DIRECTION      m_sortType;                 // UP, DOWN, NONE
     int                 m_sortedCol;                // last column that was sorted upon, WXNOT_FOUND if none
-    bool                m_bEnableSort;              // true if sorting wanted, default set
+    bool                m_bEnableSort;              // true if sorting wanted, default not set
 #endif
 };
 

--- a/src/scoreEntry.cpp
+++ b/src/scoreEntry.cpp
@@ -39,7 +39,7 @@ ScoreEntry::ScoreEntry(wxWindow* a_pParent, UINT a_pageId) :Baseframe(a_pParent,
     #define SIZE_PAIRNR     (6 * sizeOne)                       /* "AB12 *"             */
     #define SIZE_ID         (5 * sizeOne)                       /* just numbers 1-120   */
     #define SIZE_SCORE      (8 * sizeOne)                       /* 'score nz' / 'R-9999'*/
-    #define SIZE_CONTRACT   (9 * sizeOne)                       /* 3sa+3** */
+    #define SIZE_CONTRACT   (10* sizeOne)                       /* 3sa+3** */
     m_theGrid->SetColSize(COL_GAME       , SIZE_ID      ); m_theGrid->SetColLabelValue(COL_GAME       , _("game"       ));
     m_theGrid->SetColSize(COL_NS         , SIZE_PAIRNR  ); m_theGrid->SetColLabelValue(COL_NS         , _("ns"         ));
     m_theGrid->SetColSize(COL_EW         , SIZE_PAIRNR  ); m_theGrid->SetColLabelValue(COL_EW         , _("ew"         ));

--- a/src/version.h
+++ b/src/version.h
@@ -2,10 +2,10 @@
 // Distributed under the MIT License (http://opensource.org/licenses/MIT)
 
 #define __PRG_NAME__            "BridgeWx"
-#define __VERSION__             "v10.7.0"           /* like "v2.0.0" */
+#define __VERSION__             "v10.8.0"           /* like "v2.0.0" */
 #define __VERSION_MAIN__        "v10"
-#define __VERSION_NR__          10,7,0,0
-#define __PRODUCT_VERSION__     10,7,0,0
+#define __VERSION_NR__          10,8,0,0
+#define __PRODUCT_VERSION__     10,8,0,0
 #define __YEAR__                "2025"
 
 #define __VERSION__AUTO         "x9.99"             /* simulated version in autotest: less differences in output files */

--- a/tools/BuildDate.cpp
+++ b/tools/BuildDate.cpp
@@ -5,8 +5,8 @@
 // static const char* buildDate = "zaterdag 20 juli 2024 @ 16:07:36";  
 
 // locale to use when no commandline argument is given
-// #define DEFAULT_LOCALE "en-UK"
-#define DEFAULT_LOCALE GetSystemLocale()
+#define DEFAULT_LOCALE "en-UK"
+//#define DEFAULT_LOCALE GetSystemLocale()
 
 #include <Windows.h>
 #include <ctime>

--- a/tools/BuildDate.cpp
+++ b/tools/BuildDate.cpp
@@ -4,6 +4,10 @@
 // will output to console and file <.\buildDate.h> a string like:
 // static const char* buildDate = "zaterdag 20 juli 2024 @ 16:07:36";  
 
+// locale to use when no commandline argument is given
+#define DEFAULT_LOCALE "en-UK"
+//#define DEFAULT_LOCALE GetSystemLocale()
+
 #include <Windows.h>
 #include <ctime>
 #include <iostream>
@@ -97,7 +101,7 @@ void DateTime2(const char* pLocale)
     //"vrijdag 9 juli 2024 @ 20:51:51";
     std::time_t tm = std::time(nullptr);
     std::locale::global(std::locale(pLocale));
-    std::strftime(build, sizeof(build), "static const char* buildDate = \"%A %e %B %Y @ %T\";", std::localtime(&tm));
+    std::strftime(build, sizeof(build), "static const char* buildDate = \"%A, %x @ %X\";", std::localtime(&tm));
     /*
     * For non-latin languages we need to do something like:
     *   static const wchar_t* buildDate = L"xyz";
@@ -111,11 +115,16 @@ void DateTime2(const char* pLocale)
 const char compiletime[] ="<buildtime: " __DATE__ ", " __TIME__ ">";
 int main(int argc, const char* argv[])
 {
+    char buf[1000]={0};
+    if (argc > 1) sprintf(buf, ", now using <%s>", argv[1]);
+    fprintf(stderr, "%s [locale], default <%s>%s\n", argv[0], DEFAULT_LOCALE, buf);
+    fprintf(stderr, "Generates a string/file containing the buildtime in utf8.\n\n");
+
     compiletime;
     const char* utf8    = ".utf8";
-    char*       pBuf    = nullptr;   
-    auto        pLocale = (argc > 1) ? argv[1] : GetSystemLocale();
-    if (pLocale[0] == 0) pLocale = "nl-NL";
+    char*       pBuf    = nullptr;
+    auto        pLocale = (argc > 1) ? argv[1] : DEFAULT_LOCALE;
+
     if (strstr(pLocale, utf8) == nullptr)
     {   // add .utf8 for locale, so we can handle non-latin languages
         pBuf = new char[strlen(pLocale)+strlen(utf8)+1];
@@ -123,8 +132,6 @@ int main(int argc, const char* argv[])
         strcat(pBuf, utf8);
         pLocale = pBuf;
     }
-    fprintf(stderr, "%s [locale], default <%s>\n", argv[0], pLocale);
-    fprintf(stderr, "Generates a string/file containing the buildtime in utf8.\n\n");
 //    DateTime1();
 //    printf("%s", build);    // console output
 //    puts("");

--- a/tools/BuildDate.cpp
+++ b/tools/BuildDate.cpp
@@ -5,8 +5,8 @@
 // static const char* buildDate = "zaterdag 20 juli 2024 @ 16:07:36";  
 
 // locale to use when no commandline argument is given
-#define DEFAULT_LOCALE "en-UK"
-//#define DEFAULT_LOCALE GetSystemLocale()
+// #define DEFAULT_LOCALE "en-UK"
+#define DEFAULT_LOCALE GetSystemLocale()
 
 #include <Windows.h>
 #include <ctime>

--- a/tools/BuildDate.vcxproj
+++ b/tools/BuildDate.vcxproj
@@ -86,7 +86,7 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
@@ -101,7 +101,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>


### PR DESCRIPTION
 - disabled v3.3.0 feature to show highlighted grid columnlabel on activating a cell
 - when producing builddate.h, 'prebuild.bat' now defaults to 'en_UK' locales for date and time
 - use ./build/msw/wx_setup.props to get the version-dependend names of some wx libraries
 - added 'BridgeWx.props' to set needed variable(s): wxwin (base of wxWidgets version)
   - remark: if 'wxwin'is set in the environment, the BridgeWx.props file is not loaded
 - changed disabled feature:
   - bad side effect: columnheaders got a much larger margin, so many texts did not fit anymore
   - new implementation has nice side effect of having sort-icons available in the column headers
